### PR TITLE
docs: bump the change the base url example code per recent release changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,13 @@ If you are self hosting the API, or developing locally, you can change the serve
 # Using a local server
 s = unstructured_client.UnstructuredClient(
     server_url="http://localhost:8000",
-    security=shared.Security(
-        api_key_auth=api_key,
-    ),
+    api_key_auth=api_key,
 )
 
 # Using your own server
 s = unstructured_client.UnstructuredClient(
     server_url="https://your-server",
-    security=shared.Security(
-        api_key_auth=api_key,
-    ),
+    api_key_auth=api_key,
 )
 ```
 


### PR DESCRIPTION
It looks like we no longer support passing in a Security object and instead have the users directly assign `api_key_auth`, looks like this part of the README just needed the respective bump.