### PR TITLE
chore: create test

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -2,3 +2,6 @@
 
 # ignore human-written test files
 tests/test_utils_retries.py
+
+# ignore Makefile
+Makefile

--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,4 @@
+# https://www.speakeasyapi.dev/docs/customize-sdks/monkey-patching
+
+# ignore human-written test files
+tests/test_utils_retries.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+PACKAGE_NAME := unstructured-python-client
+CURRENT_DIR := $(shell pwd)
+ARCH := $(shell uname -m)
+
+###########
+# Install #
+###########
+
+test-install:
+	pip install requests_mock
+
+#################
+# Test and Lint #
+#################
+
+.PHONY: test
+test:
+	PYTHONPATH=. pytest \
+		tests

--- a/tests/test_utils_retries.py
+++ b/tests/test_utils_retries.py
@@ -11,7 +11,8 @@ from unstructured_client.utils.retries import BackoffStrategy, RetryConfig
 def get_api_key():
     api_key = os.getenv("UNS_API_KEY")
     if api_key is None:
-        raise ValueError("UNS_API_KEY environment variable not set")
+        raise ValueError("""UNS_API_KEY environment variable not set. 
+Set it in your current shell session with `export UNS_API_KEY=<api_key>`""")
     return api_key
 
 # this test requires UNS_API_KEY be set in your shell session. Ex: `export UNS_API_KEY=<api_key>`

--- a/tests/test_utils_retries.py
+++ b/tests/test_utils_retries.py
@@ -14,6 +14,7 @@ def get_api_key():
         raise ValueError("UNS_API_KEY environment variable not set")
     return api_key
 
+# this test requires UNS_API_KEY be set in your shell session. Ex: `export UNS_API_KEY=<api_key>`
 def test_backoff_strategy():
     filename = "README.md"
     backoff_strategy = BackoffStrategy(
@@ -24,7 +25,7 @@ def test_backoff_strategy():
     )
     
     with requests_mock.Mocker() as mock:
-        # mock 500 status code for POST requests to the api 
+        # mock a 500 status code for POST requests to the api 
         mock.post("https://api.unstructured.io/general/v0/general", status_code=500)
         session = UnstructuredClient(api_key_auth=get_api_key())
 

--- a/tests/test_utils_retries.py
+++ b/tests/test_utils_retries.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+
+import requests_mock
+
+from unstructured_client import UnstructuredClient
+from unstructured_client.models import shared
+from unstructured_client.utils.retries import BackoffStrategy, RetryConfig
+
+
+def get_api_key():
+    api_key = os.getenv("UNS_API_KEY")
+    if api_key is None:
+        raise ValueError("UNS_API_KEY environment variable not set")
+    return api_key
+
+def test_backoff_strategy():
+    filename = "README.md"
+    backoff_strategy = BackoffStrategy(
+        initial_interval=100, max_interval=1000, exponent=1.5, max_elapsed_time=3000
+    )
+    retries = RetryConfig(
+        strategy="backoff", backoff=backoff_strategy, retry_connection_errors=True
+    )
+    
+    with requests_mock.Mocker() as mock:
+        # mock 500 status code for POST requests to the api 
+        mock.post("https://api.unstructured.io/general/v0/general", status_code=500)
+        session = UnstructuredClient(api_key_auth=get_api_key())
+
+        with open(filename, "rb") as f:
+            files=shared.Files(
+                content=f.read(),
+                file_name=filename,
+            )
+
+        req = shared.PartitionParameters(files=files)
+
+        with pytest.raises(Exception) as excinfo:
+            resp = session.general.partition(req, retries=retries)    
+            assert resp.status_code == 500
+            assert "API error occurred" in str(excinfo.value)
+
+        # the number of retries varies
+        assert len(mock.request_history) > 1 


### PR DESCRIPTION
This PR adds a test that checks if the retry logic is operating using custom retry configurations (for the sake of time when running the test). This test also requires that an `UNS_API_KEY` be set in your local environment. This can be done by exporting it in your bash session (`export UNS_API_KEY=<api_key>`).

Additionally, it adds a `.genignore` file, which is used to tell Speakeasy to _ignore_ this test file so it is not overwritten. 