### PR TITLE
feat: support image block extraction

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,5 +1,8 @@
 # https://www.speakeasyapi.dev/docs/customize-sdks/monkey-patching
 
+# Pycharm
+.idea/
+
 # ignore human-written test files
 tests/test_utils_retries.py
 

--- a/.genignore
+++ b/.genignore
@@ -1,8 +1,5 @@
 # https://www.speakeasyapi.dev/docs/customize-sdks/monkey-patching
 
-# Pycharm
-.idea/
-
 # ignore human-written test files
 tests/test_utils_retries.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Pycharm
+.idea/
+
 venv/
 src/*.egg-info/
 __pycache__/

--- a/src/unstructured_client/utils/utils.py
+++ b/src/unstructured_client/utils/utils.py
@@ -481,16 +481,20 @@ def serialize_multipart_form(media_type: str, request: dataclass) -> Tuple[str, 
                 None, marshal_json(val, field.type), "application/json"]]
             form.append(to_append)
         else:
-            field_name = field_metadata.get(
-                "field_name", field.name)
-            if isinstance(val, List):
-                for value in val:
-                    if value is None:
-                        continue
-                    form.append(
-                        [field_name + "[]", [None, _val_to_string(value)]])
+            field_name = field_metadata.get("field_name", field.name)
+            if field_name == "extract_image_block_types":
+                # Generate a string representation of the list with double quotes
+                # e.g. '["image", "table"]'
+                form.append([field_name, [None, _val_to_string(val).replace("'", '"')]])
             else:
-                form.append([field_name, [None, _val_to_string(val)]])
+                if isinstance(val, List):
+                    for value in val:
+                        if value is None:
+                            continue
+                        form.append(
+                            [field_name + "[]", [None, _val_to_string(value)]])
+                else:
+                    form.append([field_name, [None, _val_to_string(val)]])
     return media_type, None, form
 
 


### PR DESCRIPTION
This PR added logic to pass `extract_image_block_types` parameter to API correctly.

### Testing
- `unstructured-api`
```
make run-web-app
```

- `unstructured`
```
$ pip uninstall -y unstructured-client
$ git clone -b feat/support-image-block-extraction https://github.com/Unstructured-IO/unstructured-python-client.git & cd unstructured-python-client
pip install -e .
```
Run the following code
```
from unstructured.partition.api import partition_via_api

filename = "example-docs/embedded-images-tables.pdf"

elements = partition_via_api(
    filename=filename,
    api_url="http://localhost:8000/general/v0/general",
    api_key=<api-key>,
    strategy="hi_res",
    extract_image_block_types=["image", "table"],
)
print(elements)
```
