### PR TITLE
chore: suggest url if 401

### DIFF
--- a/_test_unstructured_client/test__decorators.py
+++ b/_test_unstructured_client/test__decorators.py
@@ -51,10 +51,7 @@ def test_clean_server_url_fixes_malformed_localhost_url(server_url: str):
 
 
 def test_clean_server_url_returns_empty_string_given_empty_string():
-    client = UnstructuredClient(
-        server_url="",
-        api_key_auth=FAKE_KEY,
-    )
+    client = UnstructuredClient( server_url="", api_key_auth=FAKE_KEY)
     assert client.general.sdk_configuration.server_url == ""
 
 

--- a/_test_unstructured_client/test__decorators.py
+++ b/_test_unstructured_client/test__decorators.py
@@ -9,16 +9,18 @@ FAKE_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 
 @pytest.mark.parametrize(
-    ("server_url"),
+    "server_url",
     [
-        ("https://unstructured-000mock.api.unstructuredapp.io"),  # correct url
-        ("unstructured-000mock.api.unstructuredapp.io"),
-        ("http://unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
-        ("https://unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
-        ("unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
+        # -- well-formed url --
+        "https://unstructured-000mock.api.unstructuredapp.io",
+        # -- common malformed urls --
+        "unstructured-000mock.api.unstructuredapp.io",
+        "http://unstructured-000mock.api.unstructuredapp.io/general/v0/general",
+        "https://unstructured-000mock.api.unstructuredapp.io/general/v0/general",
+        "unstructured-000mock.api.unstructuredapp.io/general/v0/general",
     ],
 )
-def test_clean_server_url_on_paid_api_url(server_url: str):
+def test_clean_server_url_fixes_malformed_paid_api_url(server_url: str):
     client = UnstructuredClient(
         server_url=server_url,
         api_key_auth=FAKE_KEY,
@@ -30,15 +32,17 @@ def test_clean_server_url_on_paid_api_url(server_url: str):
 
 
 @pytest.mark.parametrize(
-    ("server_url"),
+    "server_url",
     [
-        ("http://localhost:8000"),  # correct url
-        ("localhost:8000"),
-        ("localhost:8000/general/v0/general"),
-        ("http://localhost:8000/general/v0/general"),
+        # -- well-formed url --
+        "http://localhost:8000",
+        # -- common malformed urls --
+        "localhost:8000",
+        "localhost:8000/general/v0/general",
+        "http://localhost:8000/general/v0/general",
     ],
 )
-def test_clean_server_url_on_localhost(server_url: str):
+def test_clean_server_url_fixes_malformed_localhost_url(server_url: str):
     client = UnstructuredClient(
         server_url=server_url,
         api_key_auth=FAKE_KEY,
@@ -46,7 +50,7 @@ def test_clean_server_url_on_localhost(server_url: str):
     assert client.general.sdk_configuration.server_url == "http://localhost:8000"
 
 
-def test_clean_server_url_on_empty_string():
+def test_clean_server_url_returns_empty_string_given_empty_string():
     client = UnstructuredClient(
         server_url="",
         api_key_auth=FAKE_KEY,
@@ -54,14 +58,25 @@ def test_clean_server_url_on_empty_string():
     assert client.general.sdk_configuration.server_url == ""
 
 
+def test_clean_server_url_returns_None_given_no_server_url():
+    client = UnstructuredClient(
+        api_key_auth=FAKE_KEY,
+    )
+    assert client.general.sdk_configuration.server_url == None
+
+
 @pytest.mark.parametrize(
-    ("server_url"),
+    "server_url",
     [
-        ("https://unstructured-000mock.api.unstructuredapp.io"),
-        ("unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
+        # -- well-formed url --
+        "https://unstructured-000mock.api.unstructuredapp.io",
+        # -- malformed url --
+        "unstructured-000mock.api.unstructuredapp.io/general/v0/general",
     ],
 )
-def test_clean_server_url_with_positional_arguments(server_url: str):
+def test_clean_server_url_fixes_malformed_urls_with_positional_arguments(
+    server_url: str,
+):
     client = UnstructuredClient(
         FAKE_KEY,
         "",
@@ -73,26 +88,26 @@ def test_clean_server_url_with_positional_arguments(server_url: str):
     )
 
 
-def test_suggest_defining_url_if_401():
-    with pytest.warns(UserWarning):
+def test_suggest_defining_url_issues_a_warning_on_a_401():
+    client = UnstructuredClient(
+        api_key_auth=FAKE_KEY,
+    )
 
-        client = UnstructuredClient(
-            api_key_auth=FAKE_KEY,
+    filename = "_sample_docs/layout-parser-paper-fast.pdf"
+
+    with open(filename, "rb") as f:
+        files = shared.Files(
+            content=f.read(),
+            file_name=filename,
         )
 
-        filename = "_sample_docs/layout-parser-paper-fast.pdf"
-
-        with open(filename, "rb") as f:
-            files = shared.Files(
-                content=f.read(),
-                file_name=filename,
-            )
-
-        req = shared.PartitionParameters(
-            files=files,
-        )
-
-        try:
+    req = shared.PartitionParameters(
+        files=files,
+    )
+    
+    with pytest.raises(SDKError, match="API error occurred: Status 401"):
+        with pytest.warns(
+            UserWarning,
+            match="If intending to use the paid API, please define `server_url` in your request.",
+        ):
             client.general.partition(req)
-        except SDKError as e:
-            print(e)

--- a/_test_unstructured_client/test__decorators.py
+++ b/_test_unstructured_client/test__decorators.py
@@ -11,29 +11,32 @@ FAKE_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 @pytest.mark.parametrize(
     ("server_url"),
     [
-        ("https://unstructured-000mock.api.unstructuredapp.io"), # correct url
+        ("https://unstructured-000mock.api.unstructuredapp.io"),  # correct url
         ("unstructured-000mock.api.unstructuredapp.io"),
         ("http://unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
         ("https://unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
         ("unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
-    ]
+    ],
 )
 def test_clean_server_url_on_paid_api_url(server_url: str):
     client = UnstructuredClient(
         server_url=server_url,
         api_key_auth=FAKE_KEY,
     )
-    assert client.general.sdk_configuration.server_url == "https://unstructured-000mock.api.unstructuredapp.io"
+    assert (
+        client.general.sdk_configuration.server_url
+        == "https://unstructured-000mock.api.unstructuredapp.io"
+    )
 
 
 @pytest.mark.parametrize(
     ("server_url"),
     [
-        ("http://localhost:8000"), # correct url
+        ("http://localhost:8000"),  # correct url
         ("localhost:8000"),
         ("localhost:8000/general/v0/general"),
         ("http://localhost:8000/general/v0/general"),
-    ]
+    ],
 )
 def test_clean_server_url_on_localhost(server_url: str):
     client = UnstructuredClient(
@@ -56,7 +59,7 @@ def test_clean_server_url_on_empty_string():
     [
         ("https://unstructured-000mock.api.unstructuredapp.io"),
         ("unstructured-000mock.api.unstructuredapp.io/general/v0/general"),
-    ]
+    ],
 )
 def test_clean_server_url_with_positional_arguments(server_url: str):
     client = UnstructuredClient(
@@ -64,7 +67,10 @@ def test_clean_server_url_with_positional_arguments(server_url: str):
         "",
         server_url,
     )
-    assert client.general.sdk_configuration.server_url == "https://unstructured-000mock.api.unstructuredapp.io"
+    assert (
+        client.general.sdk_configuration.server_url
+        == "https://unstructured-000mock.api.unstructuredapp.io"
+    )
 
 
 def test_suggest_defining_url_if_401():
@@ -73,11 +79,11 @@ def test_suggest_defining_url_if_401():
         client = UnstructuredClient(
             api_key_auth=FAKE_KEY,
         )
-        
+
         filename = "_sample_docs/layout-parser-paper-fast.pdf"
-        
+
         with open(filename, "rb") as f:
-            files=shared.Files(
+            files = shared.Files(
                 content=f.read(),
                 file_name=filename,
             )

--- a/src/unstructured_client/general.py
+++ b/src/unstructured_client/general.py
@@ -4,6 +4,8 @@ from .sdkconfiguration import SDKConfiguration
 from typing import Any, List, Optional
 from unstructured_client import utils
 from unstructured_client.models import errors, operations, shared
+from unstructured_client.utils._decorators import suggest_defining_url_if_401 # human code
+
 
 class General:
     sdk_configuration: SDKConfiguration
@@ -12,7 +14,7 @@ class General:
         self.sdk_configuration = sdk_config
         
     
-    
+    @suggest_defining_url_if_401 # human code
     def partition(self, request: Optional[shared.PartitionParameters], retries: Optional[utils.RetryConfig] = None) -> operations.PartitionResponse:
         r"""Pipeline 1"""
         base_url = utils.template_url(*self.sdk_configuration.get_server_details())

--- a/src/unstructured_client/sdk.py
+++ b/src/unstructured_client/sdk.py
@@ -6,7 +6,7 @@ from .sdkconfiguration import SDKConfiguration
 from typing import Callable, Dict, Union
 from unstructured_client import utils
 from unstructured_client.models import shared
-from unstructured_client.utils._decorators import clean_server_url
+from unstructured_client.utils._decorators import clean_server_url # human code
 
 class UnstructuredClient:
     r"""Unstructured Pipeline API: Partition documents with the Unstructured library"""
@@ -14,7 +14,7 @@ class UnstructuredClient:
 
     sdk_configuration: SDKConfiguration
 
-    @clean_server_url
+    @clean_server_url # human code
     def __init__(self,
                  api_key_auth: Union[str, Callable[[], str]],
                  server: str = None,

--- a/src/unstructured_client/utils/_decorators.py
+++ b/src/unstructured_client/utils/_decorators.py
@@ -6,7 +6,7 @@ from typing_extensions import ParamSpec
 from urllib.parse import urlparse, urlunparse, ParseResult
 import warnings
 
-from unstructured_client.models import errors
+from unstructured_client.models import errors, operations
 
 if TYPE_CHECKING:
     from unstructured_client.general import General
@@ -52,14 +52,14 @@ def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
     return wrapper
 
 
-def suggest_defining_url_if_401(func: Callable[_P, None]) -> Callable[_P, None]:
+def suggest_defining_url_if_401(func: Callable[_P, operations.PartitionResponse]) -> Callable[_P, operations.PartitionResponse]:
 
     @functools.wraps(func)
-    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> operations.PartitionResponse:
         try:
             return func(*args, **kwargs)
         except errors.SDKError:
-            general_obj: General = args[0]
+            general_obj: General = args[0] # type: ignore
             if not general_obj.sdk_configuration.server_url:
                 warnings.warn("If intending to use the paid API, please define `server_url` in your request.")
             return func(*args, **kwargs)

--- a/src/unstructured_client/utils/_decorators.py
+++ b/src/unstructured_client/utils/_decorators.py
@@ -58,10 +58,12 @@ def suggest_defining_url_if_401(func: Callable[_P, operations.PartitionResponse]
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> operations.PartitionResponse:
         try:
             return func(*args, **kwargs)
-        except errors.SDKError:
-            general_obj: General = args[0] # type: ignore
-            if not general_obj.sdk_configuration.server_url:
-                warnings.warn("If intending to use the paid API, please define `server_url` in your request.")
+        except errors.SDKError as e:
+            if e.status_code == 401:
+                general_obj: General = args[0] # type: ignore
+                if not general_obj.sdk_configuration.server_url:
+                    warnings.warn("If intending to use the paid API, please define `server_url` in your request.")
+            
             return func(*args, **kwargs)
 
     return wrapper

--- a/src/unstructured_client/utils/_decorators.py
+++ b/src/unstructured_client/utils/_decorators.py
@@ -16,6 +16,13 @@ _P = ParamSpec("_P")
 
 
 def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
+    """A decorator for fixing common types of malformed 'server_url' arguments.
+
+    This decorator addresses the common problem of users omitting or using the wrong url scheme and/or
+    adding the '/general/v0/general' path to the 'server_url'.
+    The decorator should be manually applied to the __init__ method of UnstructuredClient after merging
+    a PR from Speakeasy.
+    """
 
     @functools.wraps(func)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
@@ -55,7 +62,11 @@ def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
 def suggest_defining_url_if_401(
     func: Callable[_P, operations.PartitionResponse]
 ) -> Callable[_P, operations.PartitionResponse]:
-
+    """A decorator to suggest defining the 'server_url' parameter if a 401 Unauthorized error is encountered.
+    
+    This decorator addresses the common problem of users not passing in the 'server_url' when using their paid api key.
+    The decorator should be manually applied to General.partition after merging a PR from Speakeasy.
+    """
     @functools.wraps(func)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> operations.PartitionResponse:
         try:

--- a/src/unstructured_client/utils/_decorators.py
+++ b/src/unstructured_client/utils/_decorators.py
@@ -18,10 +18,9 @@ _P = ParamSpec("_P")
 def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
     """A decorator for fixing common types of malformed 'server_url' arguments.
 
-    This decorator addresses the common problem of users omitting or using the wrong url scheme and/or
-    adding the '/general/v0/general' path to the 'server_url'.
-    The decorator should be manually applied to the __init__ method of UnstructuredClient after merging
-    a PR from Speakeasy.
+    This decorator addresses the common problem of users omitting or using the wrong url scheme
+    and/or adding the '/general/v0/general' path to the 'server_url'. The decorator should be
+    manually applied to the __init__ method of UnstructuredClient after merging a PR from Speakeasy.
     """
 
     @functools.wraps(func)
@@ -52,7 +51,11 @@ def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
             if url_is_in_kwargs:
                 kwargs["server_url"] = urlunparse(cleaned_url)
             else:
-                args = args[:SERVER_URL_ARG_IDX] + (urlunparse(cleaned_url),) + args[SERVER_URL_ARG_IDX + 1 :]  # type: ignore
+                args = (
+                    args[:SERVER_URL_ARG_IDX]
+                    + (urlunparse(cleaned_url),)
+                    + args[SERVER_URL_ARG_IDX + 1 :]
+                )  # type: ignore
 
         return func(*args, **kwargs)
 
@@ -62,11 +65,14 @@ def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
 def suggest_defining_url_if_401(
     func: Callable[_P, operations.PartitionResponse]
 ) -> Callable[_P, operations.PartitionResponse]:
-    """A decorator to suggest defining the 'server_url' parameter if a 401 Unauthorized error is encountered.
-    
-    This decorator addresses the common problem of users not passing in the 'server_url' when using their paid api key.
-    The decorator should be manually applied to General.partition after merging a PR from Speakeasy.
+    """A decorator to suggest defining the 'server_url' parameter if a 401 Unauthorized error is
+    encountered.
+
+    This decorator addresses the common problem of users not passing in the 'server_url' when
+    using their paid api key. The decorator should be manually applied to General.partition after
+    merging a PR from Speakeasy.
     """
+
     @functools.wraps(func)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> operations.PartitionResponse:
         try:

--- a/src/unstructured_client/utils/_decorators.py
+++ b/src/unstructured_client/utils/_decorators.py
@@ -45,14 +45,16 @@ def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
             if url_is_in_kwargs:
                 kwargs["server_url"] = urlunparse(cleaned_url)
             else:
-                args = args[:SERVER_URL_ARG_IDX] + (urlunparse(cleaned_url),) + args[SERVER_URL_ARG_IDX+1:] # type: ignore
-        
+                args = args[:SERVER_URL_ARG_IDX] + (urlunparse(cleaned_url),) + args[SERVER_URL_ARG_IDX + 1 :]  # type: ignore
+
         return func(*args, **kwargs)
 
     return wrapper
 
 
-def suggest_defining_url_if_401(func: Callable[_P, operations.PartitionResponse]) -> Callable[_P, operations.PartitionResponse]:
+def suggest_defining_url_if_401(
+    func: Callable[_P, operations.PartitionResponse]
+) -> Callable[_P, operations.PartitionResponse]:
 
     @functools.wraps(func)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> operations.PartitionResponse:
@@ -60,10 +62,12 @@ def suggest_defining_url_if_401(func: Callable[_P, operations.PartitionResponse]
             return func(*args, **kwargs)
         except errors.SDKError as e:
             if e.status_code == 401:
-                general_obj: General = args[0] # type: ignore
+                general_obj: General = args[0]  # type: ignore
                 if not general_obj.sdk_configuration.server_url:
-                    warnings.warn("If intending to use the paid API, please define `server_url` in your request.")
-            
+                    warnings.warn(
+                        "If intending to use the paid API, please define `server_url` in your request."
+                    )
+
             return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Final PR for closing #30 

This PR adds a decorator to the `partition` method of the `General` class to catch if a 401 error is being raised while `server_url` is `None` and add a warning message.

Testing
```
from unstructured_client.models import shared
from unstructured_client import UnstructuredClient

FAKE_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

client = UnstructuredClient(
    api_key_auth=FAKE_KEY,
)
        
filename = "_sample_docs/layout-parser-paper-fast.pdf"
        
with open(filename, "rb") as f:
   files=shared.Files(
        content=f.read(),
        file_name=filename,
   )

req = shared.PartitionParameters(
    files=files,
)

client.general.partition(req)
```