### PR TITLE
chore: add 'make lint' command and address linting error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,14 @@ ARCH := $(shell uname -m)
 ###########
 
 .PHONY: install-test
+install-test:
 	pip install pytest
 	pip install requests_mock
 
 .PHONY: install-dev
+install-dev:
 	pip install jupyter
+	pip install pylint
 
 ## install:					installs all test, dev, and experimental requirements
 .PHONY: install
@@ -25,6 +28,10 @@ install: install-test install-dev
 test:
 	PYTHONPATH=. pytest \
 		_test_unstructured_client
+
+.PHONY: lint
+lint:
+	pylint --rcfile=pylintrc src
 
 ###########
 # Jupyter #

--- a/src/unstructured_client/utils/_decorators.py
+++ b/src/unstructured_client/utils/_decorators.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 
 _P = ParamSpec("_P")
+SERVER_URL_ARG_IDX = 3
 
 
 def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
@@ -25,7 +26,6 @@ def clean_server_url(func: Callable[_P, None]) -> Callable[_P, None]:
 
     @functools.wraps(func)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
-        SERVER_URL_ARG_IDX = 3
         url_is_in_kwargs = True
 
         server_url: Optional[str] = cast(Optional[str], kwargs.get("server_url"))


### PR DESCRIPTION
follow-up from #30 and #32

This adds a `make lint` command that uses the `pylintrc` file Speakeasy creates so that we can check if our changes will pass.

This also moves a global variable to the appropriate scope so the linting passes.