### PR TITLE
Move the openapi source of truth

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -24,7 +24,7 @@ jobs:
       create_release: true
       openapi_doc_auth_header: x-api-key
       openapi_docs: |
-        - https://raw.githubusercontent.com/Unstructured-IO/unstructured-api/main/openapi.json
+        - https://api.unstructured.io/general/openapi.json
       publish_python: true
       speakeasy_version: latest
     secrets:


### PR DESCRIPTION
We're now generating our openapi spec out of FastAPI. This means we can go straight to the hosted spec instead of duplicating the file in github.