### PR TITLE
Disable the publish job

### DIFF
--- a/.github/workflows/speakeasy_sdk_publish.yaml
+++ b/.github/workflows/speakeasy_sdk_publish.yaml
@@ -9,8 +9,8 @@ jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14
     with:
-      create_release: true
-      publish_python: true
+      create_release: false
+      publish_python: false
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
Mirror of the js change here: https://github.com/Unstructured-IO/unstructured-js-client/pull/38/files

We'd like to coordinate some breaking changes in the clients before starting to publish again.