### PR TITLE
chore: Use the hosted api spec for generation

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -2,7 +2,7 @@ workflowVersion: 1.0.0
 sources:
     my-source:
         inputs:
-            - location: https://raw.githubusercontent.com/Unstructured-IO/unstructured-api/main/openapi.json
+            - location: https://api.unstructured.io/general/openapi.json
         overlays:
             - location: ./overlay_client.yaml
 targets:


### PR DESCRIPTION
The interface will change slightly, and we'll provide a migration guide before enabling publishing again.