### PR TITLE
chore/docs: code samples for docs repo

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -12,3 +12,5 @@ targets:
     unstructured-python:
         target: python
         source: my-source
+        codeSamples:
+            output: codeSamples.yaml


### PR DESCRIPTION
Setup for integrating Speakeasy generated code snippets directly into our Mintlify docs repo
https://www.speakeasyapi.dev/docs/mintlify#manual-setup

Also see https://github.com/Unstructured-IO/docs/pull/36