### PR TITLE
feat: use ThreadPoolExecutor

### DIFF
--- a/_test_unstructured_client/integration/test_integration_freemium.py
+++ b/_test_unstructured_client/integration/test_integration_freemium.py
@@ -5,6 +5,8 @@ import pytest
 import requests
 from unstructured_client import UnstructuredClient
 from unstructured_client.models import shared
+from unstructured_client.utils.retries import RetryConfig, BackoffStrategy
+from unstructured_client.models.errors.sdkerror import SDKError
 
 
 @pytest.fixture(scope="module")
@@ -18,8 +20,9 @@ def doc_path() -> Path:
     return Path(__file__).resolve().parents[2] / "_sample_docs"
 
 
+@pytest.mark.parametrize("split_pdf", [True, False])
 @pytest.mark.parametrize("strategy", ["fast", "ocr_only", "hi_res"])
-def test_partition_strategies(strategy, client, doc_path):
+def test_partition_strategies(split_pdf, strategy, client, doc_path):
     filename = "layout-parser-paper-fast.pdf"
     with open(doc_path / filename, "rb") as f:
         files = shared.Files(
@@ -31,8 +34,43 @@ def test_partition_strategies(strategy, client, doc_path):
         files=files,
         strategy=strategy,
         languages=["eng"],
+        split_pdf_page=split_pdf,
     )
 
     response = client.general.partition(req)
     assert response.status_code == 200
     assert len(response.elements)
+
+
+@pytest.mark.parametrize("split_pdf", [True, False])
+@pytest.mark.parametrize("error_code", [500, 403])
+def test_partition_handling_server_error(error_code, split_pdf,monkeypatch, doc_path):
+    filename = "layout-parser-paper-fast.pdf"
+    from unstructured_client.sdkconfiguration import requests_http
+
+    response = requests_http.Response()
+    response.status_code = error_code
+    monkeypatch.setattr(requests_http.Session, "send", lambda *args, **kwargs: response)
+
+    # initialize client after patching
+    client = UnstructuredClient(
+        api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
+        retry_config=RetryConfig("backoff", BackoffStrategy(1, 10, 1.5, 30), False),
+    )
+
+    with open(doc_path / filename, "rb") as f:
+        files = shared.Files(
+            content=f.read(),
+            file_name=filename,
+        )
+
+    req = shared.PartitionParameters(
+        files=files,
+        strategy="fast",
+        languages=["eng"],
+        split_pdf_page=split_pdf,
+    )
+
+    with pytest.raises(SDKError, match=f"API error occurred: Status {error_code}"):
+        response = client.general.partition(req)
+

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -4,7 +4,6 @@ import functools
 import io
 import logging
 import math
-import platform
 # NOTE: on Windows Process based multiprocessing has to be run in __main__ so to ensure the client
 # works on Windows we use Thread based multiprocessing
 from concurrent.futures import Future, ThreadPoolExecutor

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -5,7 +5,9 @@ import io
 import logging
 import math
 import platform
-from concurrent.futures import Future, ProcessPoolExecutor
+# NOTE: on Windows Process based multiprocessing has to be run in __main__ so to ensure the client
+# works on Windows we use Thread based multiprocessing
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Optional, Tuple, Union
 
 import requests
@@ -39,12 +41,6 @@ DEFAULT_CONCURRENCY_LEVEL = 5
 MAX_CONCURRENCY_LEVEL = 15
 MIN_PAGES_PER_SPLIT = 2
 MAX_PAGES_PER_SPLIT = 20
-
-
-if platform.system() == "Darwin":
-    import multiprocessing
-
-    multiprocessing.set_start_method("fork", force=True)
 
 
 def get_optimal_split_size(num_pages: int, concurrency_level: int) -> int:
@@ -152,7 +148,7 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         self.partition_requests[operation_id] = []
         last_page_content = io.BytesIO()
         last_page_number = 0
-        with ProcessPoolExecutor(max_workers=concurrency_level) as executor:
+        with ThreadPoolExecutor(max_workers=concurrency_level) as executor:
             for page_content, page_index, all_pages_number in pages:
                 page_number = page_index + starting_page_number
                 # Check if this page is the last one


### PR DESCRIPTION
- to allow Windows to run pdf splitting with the sdk we switch from Process based to Thread based multiprocessing
- add integration test to verify the client can handle pdf splitting with successful server response and unsuccessful responses

## tests ran

- macOS
- Linux (ci)
- Windows 11 (with powershell)
- WSL (ubuntu)