### PR TITLE
fix: Fix optional params defaulting to __SPEAKEASY_UNSET__

### DIFF
--- a/overlay_client.yaml
+++ b/overlay_client.yaml
@@ -21,3 +21,7 @@ actions:
           "type": "integer",
           "default": 5,
         }
+  - target: $["components"]["schemas"]["partition_parameters"]["properties"][*].anyOf[0]
+    description: Add a null default to all optional parameters. Prevents the sdk from sending a default string when param is not specified.
+    update:
+        "default": null


### PR DESCRIPTION
See #94 for example. Our api uses `anyOf` for optional params, and if there's no default value, the client sets the default __SPEAKEASY_UNSET__. This string gets sent for all optional params and causes the server to basically always return a validation error.

We need to add a null default like so:
```
     "combine_under_n_chars": {
          "anyOf": [
              {
                  "type": "integer",
                  "default": null
              },
              {
                  "type": "null"
              }
          ],
      },
```

However, doing this on the server breaks the js-client. Over there, optional params are undefined by default, and adding a null default causes us to send a literal `null`, causing the same validation issues.

Thus the fix is to set the defaults only on the python side and remove the workaround on the server.

To test, run `make client-generate && make test`.