### PR TITLE
fix/allow asyncio page splitting in nested event loops

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         "jsonpath-python>=1.0.6",
         "marshmallow>=3.19.0",
         "mypy-extensions>=1.0.0",
+        "nest-asyncio>=1.6.0",
         "packaging>=23.1",
         "pypdf>=4.0",
         "python-dateutil>=2.8.2",

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -8,6 +8,7 @@ import math
 from typing import Any, Coroutine, Optional, Tuple, Union
 
 import httpx
+import nest_asyncio
 import requests
 from pypdf import PdfReader
 from requests_toolbelt.multipart.decoder import MultipartDecoder
@@ -39,6 +40,8 @@ DEFAULT_CONCURRENCY_LEVEL = 5
 MAX_CONCURRENCY_LEVEL = 15
 MIN_PAGES_PER_SPLIT = 2
 MAX_PAGES_PER_SPLIT = 20
+
+nest_asyncio.apply()
 
 
 async def run_tasks(tasks):


### PR DESCRIPTION
We're now using asyncio for page split concurrency, but because the client itself is not async, we need to manage our own event loop. This complains if your environment already has a running event loop. For instance, setting `split_pdf_page=True` in a jupyter cell will give you `RuntimeError: This event loop is already running`.

Turns out there's a simple library to allow for nested event loops. We just apply the monkeypatch in split_pdf_hook.py and the error goes away.

To verify, you'll need to install the current client on main, test in jupyter, then install on this branch and verify the error is gone.
* Checkout the main branch and run `pip install -e .` in your pyenv to install the local version of the client
* Run `make run-jupyter` and open up the sample notebook in `_jupyter/`. 
* Update the sample code to use `split_pdf_page=True`. Change the `server_url` to hit your local server, or add your freemium api key to the snippet. Once the result starts coming back, you should get the above error.
* Checkout this branch and install locally again
* Restart your kernel and try your snippet again. The error should be gone.