### PR TITLE
fix/Move the nest-asyncio apply into an init hook

### DIFF
--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -41,7 +41,6 @@ MAX_CONCURRENCY_LEVEL = 15
 MIN_PAGES_PER_SPLIT = 2
 MAX_PAGES_PER_SPLIT = 20
 
-nest_asyncio.apply()
 
 
 async def run_tasks(tasks):
@@ -69,6 +68,10 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
     """
 
     def __init__(self) -> None:
+        # This allows us to use an event loop in an env with an existing loop
+        # Temporary fix until we can improve the async splitting behavior
+        nest_asyncio.apply()
+
         self.client: Optional[requests.Session] = None
         self.coroutines_to_execute: dict[
             str, list[Coroutine[Any, Any, requests.Response]]


### PR DESCRIPTION
We're seeing an issue where the nest_asyncio.apply() workaround for nested loops is breaking when we're dealing with a `uvloop`. We need to investigate further, or remove the bandaid solution. In the meantime, we can unblock a simple import of the client in these environments by doing the apply only when the hook is run.