### PR TITLE
fix: remove false success log & improve retry log

### DIFF
--- a/src/unstructured_client/_hooks/custom/logger_hook.py
+++ b/src/unstructured_client/_hooks/custom/logger_hook.py
@@ -21,7 +21,7 @@ class LoggerHook(AfterErrorHook, SDKInitHook):
     def __init__(self) -> None:
         self.retries_counter: DefaultDict[str, int] = defaultdict(int)
 
-    def log_retries(self, response: Optional[requests.Response], operation_id: str):
+    def log_retries(self, response: Optional[requests.Response],  error: Optional[Exception], operation_id: str,):
         """Log retries to give users visibility into requests."""
 
         if response is not None and response.status_code // 100 == 5:
@@ -33,6 +33,20 @@ class LoggerHook(AfterErrorHook, SDKInitHook):
             )
             if response.text:
                 logger.info("Server message - %s", response.text)
+        
+        elif error is not None and isinstance(error, requests.exceptions.ConnectionError):
+            logger.info(
+                "Failed to process a request due to connection error - %s. "
+                "Attempting retry number %d after sleep.",
+                error,
+                self.retries_counter[operation_id],
+            )
+        else:
+            logger.error("Failed to partition the document.")
+            if response is not None:
+                logging.error("Server responded with %d - %s", response.status_code, response.text)
+            if error is not None:
+                logging.error("Following error occurred - %s", error)
 
     def sdk_init(
         self, base_url: str, client: requests.Session
@@ -44,6 +58,7 @@ class LoggerHook(AfterErrorHook, SDKInitHook):
         self, hook_ctx: AfterSuccessContext, response: requests.Response
     ) -> Union[requests.Response, Exception]:
         del self.retries_counter[hook_ctx.operation_id]
+        logging.info("Successfully partitioned the document.")
         return response
 
     def after_error(
@@ -54,5 +69,5 @@ class LoggerHook(AfterErrorHook, SDKInitHook):
     ) -> Union[Tuple[Optional[requests.Response], Optional[Exception]], Exception]:
         """Concrete implementation for AfterErrorHook."""
         self.retries_counter[hook_ctx.operation_id] += 1
-        self.log_retries(response, hook_ctx.operation_id)
+        self.log_retries(response, error, hook_ctx.operation_id)
         return response, error

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -299,7 +299,6 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
 
         updated_response = request_utils.create_response(response, elements)
         self._clear_operation(operation_id)
-        logger.info("Successfully processed the request.")
         return updated_response
 
     def after_error(
@@ -332,13 +331,9 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         successful_responses = self.api_successful_responses.get(operation_id)
 
         if elements is None or successful_responses is None:
-            logger.info("Successfully processed the request.")
             return (response, error)
 
         if len(successful_responses) == 0:
-            logger.error("Failed to process the request.")
-            if error is not None:
-                logger.error(error)
             self._clear_operation(operation_id)
             return (response, error)
 
@@ -346,7 +341,6 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
             successful_responses[0], elements
         )
         self._clear_operation(operation_id)
-        logger.info("Successfully processed the request.")
         return (updated_response, None)
 
     def _clear_operation(self, operation_id: str) -> None:

--- a/src/unstructured_client/_hooks/registration.py
+++ b/src/unstructured_client/_hooks/registration.py
@@ -41,4 +41,6 @@ def init_hooks(hooks: Hooks):
     # Register After Error hooks
     hooks.register_after_error_hook(suggest_defining_url_hook)
     hooks.register_after_error_hook(split_pdf_hook)
-    hooks.register_after_error_hook(logger_hook)
+    # NOTE: logger_hook should stay registered last as logs the status of
+    # request and whether it will be retried which can be changed by e.g. split_pdf_hook
+    hooks.register_after_error_hook(logger_hook)  


### PR DESCRIPTION
In the PR introducing more logging two things turned out lacking:
- there was a false success log in split-page after error hook
- the retry logs were only for 5XX responses where speakeasy also has retry set for ConnectionError exceptions

This PR removes the faulty success log, moves success/failure logs to the `LoggerHook` and introduces logging for `ConnectionError` retries.