### PR TITLE
chore: update 401 warning hook for new default url

### DIFF
--- a/_test_unstructured_client/integration/test_integration_freemium.py
+++ b/_test_unstructured_client/integration/test_integration_freemium.py
@@ -12,7 +12,7 @@ from unstructured_client.utils.retries import BackoffStrategy, RetryConfig
 
 @pytest.fixture(scope="module")
 def client() -> UnstructuredClient:
-    _client = UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"))
+    _client = UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"), server='free-api')
     yield _client
 
 

--- a/gen.yaml
+++ b/gen.yaml
@@ -10,7 +10,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 python:
-  version: 0.24.1
+  version: 0.25.0
   additionalDependencies:
     dependencies:
       deepdiff: '>=6.0'

--- a/src/unstructured_client/_hooks/custom/suggest_defining_url.py
+++ b/src/unstructured_client/_hooks/custom/suggest_defining_url.py
@@ -1,19 +1,22 @@
 from typing import Optional, Tuple, Union
-import warnings
 
+import logging
 import requests
 
+from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_NAME
 from unstructured_client._hooks.types import AfterErrorContext, AfterErrorHook
+
+logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
 
 
 class SuggestDefiningUrlIf401AfterErrorHook(AfterErrorHook):
     """Hook advising users to check that 'server_url' is defined if a 401 error is encountered."""
 
     def warn_if_401(self, response: Optional[requests.Response]):
-        """Suggest defining 'server_url' if a 401 error is encountered."""
+        """If the paid API returns 401, warn the user in case they meant to use the free api."""
         if response is not None and response.status_code == 401:
-            warnings.warn(
-                "If intending to use the paid API, please define `server_url` in your request."
+            logger.warning(
+                "This API key is invalid against the paid API. If intending to use the free API, please initialize UnstructuredClient with `server='free-api'`."
             )
 
     def after_error(


### PR DESCRIPTION
The default server url is changing to serverless. Therefore, if you get a 401, we should suggest that you meant to use the free api. Also, bump the minor version in anticipation of the url change.