### PR TITLE
fix: Do not throw error when in a uvloop context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_IMAGE ?= downloads.unstructured.io/unstructured-io/unstructured-api:lates
 
 .PHONY: install-test
 install-test:
-	pip install pytest pytest-asyncio pytest-mock requests_mock pypdf deepdiff requests-toolbelt
+	pip install pytest pytest-asyncio pytest-mock requests_mock pypdf deepdiff requests-toolbelt uvloop
 
 .PHONY: install-dev
 install-dev:

--- a/_test_unstructured_client/integration/test_integration_freemium.py
+++ b/_test_unstructured_client/integration/test_integration_freemium.py
@@ -91,3 +91,32 @@ def test_partition_handling_server_error(error, split_pdf, monkeypatch, doc_path
 
     with pytest.raises(sdk_raises):
         response = client.general.partition(req)
+
+
+def test_uvloop_partitions_without_errors(client, doc_path):
+    async def call_api():
+        filename = "layout-parser-paper-fast.pdf"
+        with open(doc_path / filename, "rb") as f:
+            files = shared.Files(
+                content=f.read(),
+                file_name=filename,
+            )
+
+        req = shared.PartitionParameters(
+            files=files,
+            strategy="fast",
+            languages=["eng"],
+            split_pdf_page=True,
+        )
+
+        resp = client.general.partition(req)
+
+        if resp is not None:
+            return resp.elements
+        else:
+            return []
+
+    import uvloop
+    uvloop.install()
+    elements = asyncio.run(call_api())
+    assert len(elements) > 0

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -76,7 +76,7 @@ async def run_tasks(coroutines: list[Awaitable], allow_failed: bool = False) -> 
 def context_is_uvloop():
     """Return true if uvloop is installed and we're currently in a uvloop context. Our asyncio splitting code currently doesn't work under uvloop."""
     try:
-        import uvloop
+        import uvloop  # pylint: disable=import-outside-toplevel
         loop = asyncio.get_event_loop()
         return isinstance(loop, uvloop.Loop)
     except ImportError:
@@ -126,6 +126,8 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         self.client = client
         return base_url, client
 
+
+    # pylint: disable=too-many-return-statements
     def before_request(
             self, hook_ctx: BeforeRequestContext, request: requests.PreparedRequest
     ) -> Union[requests.PreparedRequest, Exception]:


### PR DESCRIPTION
PDF page splitting uses asyncio but the SDK is not async. Therefore, we had to manage our own event loop, which can lead to issues in other event loop contexts. Uvloop is one context that does not allow us to use nested event loops. When we find ourselves in a uvloop.Loop, we have to fallback to non splitting mode. #135 will make the whole SDK async so we don't have to hack this.

Closes #133 