### PR TITLE
fix: handle RuntimeError when checking if we can use pdf split mode

### DIFF
--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -79,7 +79,7 @@ def context_is_uvloop():
         import uvloop  # pylint: disable=import-outside-toplevel
         loop = asyncio.get_event_loop()
         return isinstance(loop, uvloop.Loop)
-    except ImportError:
+    except (ImportError, RuntimeError):
         return False
 
 def get_optimal_split_size(num_pages: int, concurrency_level: int) -> int:


### PR DESCRIPTION
Certain environments throw a `RuntimeError: There is no current event loop in thread 'asyncio_0'` when we try to check if we're able to use the splitting code. In this case, return False so we can fallback to non split mode.

Once this is merged, I can regenerate the client to publish 0.25.4.