### PR TITLE
fix: Fix CI failures after new 0.26.0 (beta) merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
-      run: pip install pylint
+      run: pip install . && make install-dev
     - name: Lint
       run: make lint
 

--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -24,11 +24,10 @@ jobs:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}
             pypi_token: ${{ secrets.PYPI_TOKEN }}
             speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-  # We don't need this unless we're modifying the generated code
-  patch-custom-code:
-    runs-on: ubuntu-latest
-    needs: [generate]
-    steps:
-    - name: Patch in custom code after regenerating
-      run: make patch-custom-code
+    patch-custom-code:
+      runs-on: ubuntu-latest
+      needs: [generate]
+      steps:
+      - name: Patch in custom code after regenerating
+        run: make patch-custom-code
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
   <p>Python SDK for the Unstructured API</p>
 </h2>
 
+NOTE: This README is for the `0.26.0-beta` version. The current published SDK, `0.25.5` can be found [here](https://github.com/Unstructured-IO/unstructured-python-client/blob/v0.25.5/README.md).
+
 This is a Python client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/overview).
 
 Please refer to the [Unstructured docs](https://docs.unstructured.io/api-reference/api-services/sdk-python) for a full guide to using the client.


### PR DESCRIPTION
* Run the right install command before running `make lint`
* Fix indentation error with the new `patch-custom-code` step