### PR TITLE
fix: Address mypy typing errors in v2 SDK

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -24,10 +24,3 @@ jobs:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}
             pypi_token: ${{ secrets.PYPI_TOKEN }}
             speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-    patch-custom-code:
-      runs-on: ubuntu-latest
-      needs: [generate]
-      steps:
-      - name: Patch in custom code after regenerating
-        run: make patch-custom-code
-

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ install-test:
 
 .PHONY: install-dev
 install-dev:
-	pip install jupyter uvloop
-	pip install pylint mypy
+	pip install jupyter uvloop pylint mypy
 
 ## install:					installs all test, dev, and experimental requirements
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install-test:
 
 .PHONY: install-dev
 install-dev:
-	pip install jupyter
+	pip install jupyter uvloop
 	pip install pylint mypy
 
 ## install:					installs all test, dev, and experimental requirements

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install-test:
 .PHONY: install-dev
 install-dev:
 	pip install jupyter
-	pip install pylint
+	pip install pylint mypy
 
 ## install:					installs all test, dev, and experimental requirements
 .PHONY: install
@@ -48,6 +48,7 @@ test-integration-docker:
 .PHONY: lint
 lint:
 	pylint --rcfile=pylintrc src
+	mypy src
 
 #############
 # Speakeasy #

--- a/src/unstructured_client/_hooks/custom/form_utils.py
+++ b/src/unstructured_client/_hooks/custom/form_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Union
 
-from requests_toolbelt.multipart.decoder import MultipartDecoder
+from requests_toolbelt.multipart.decoder import MultipartDecoder  # type: ignore
 
 from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_NAME
 from unstructured_client.models import shared
@@ -35,7 +35,7 @@ def get_page_range(form_data: FormData, key: str, max_pages: int) -> tuple[int, 
     try:
         _page_range = form_data.get(key)
 
-        if _page_range is not None:
+        if _page_range is not None and isinstance(_page_range, list):
             page_range = (int(_page_range[0]), int(_page_range[1]))
         else:
             page_range = (1, max_pages)
@@ -108,7 +108,7 @@ def get_split_pdf_allow_failed_param(
     """
     allow_failed = form_data.get(key)
 
-    if allow_failed is None:
+    if allow_failed is None or not isinstance(allow_failed, str):
         return fallback_value
 
     if allow_failed.lower() not in ["true", "false"]:
@@ -120,6 +120,7 @@ def get_split_pdf_allow_failed_param(
         return fallback_value
 
     return allow_failed.lower() == "true"
+
 
 def get_split_pdf_concurrency_level_param(
     form_data: FormData, key: str, fallback_value: int, max_allowed: int
@@ -140,7 +141,7 @@ def get_split_pdf_concurrency_level_param(
     """
     concurrency_level_str = form_data.get(key)
 
-    if concurrency_level_str is None:
+    if concurrency_level_str is None or not isinstance(concurrency_level_str, str):
         return fallback_value
 
     try:
@@ -218,10 +219,12 @@ def parse_form_data(decoded_data: MultipartDecoder) -> FormData:
         else:
             content = part.content.decode()
             if name in form_data:
-                if isinstance(form_data[name], list):
-                    form_data[name].append(content)
+                form_data_value = form_data[name]
+                if isinstance(form_data_value, list):
+                    form_data_value.append(content)
                 else:
-                    form_data[name] = [form_data[name], content]
+                    new_list = [form_data_value, content]
+                    form_data[name] = new_list
             else:
                 form_data[name] = content
 

--- a/src/unstructured_client/_hooks/custom/form_utils.py
+++ b/src/unstructured_client/_hooks/custom/form_utils.py
@@ -35,7 +35,7 @@ def get_page_range(form_data: FormData, key: str, max_pages: int) -> tuple[int, 
     try:
         _page_range = form_data.get(key)
 
-        if _page_range is not None and isinstance(_page_range, list):
+        if isinstance(_page_range, list):
             page_range = (int(_page_range[0]), int(_page_range[1]))
         else:
             page_range = (1, max_pages)
@@ -108,7 +108,7 @@ def get_split_pdf_allow_failed_param(
     """
     allow_failed = form_data.get(key)
 
-    if allow_failed is None or not isinstance(allow_failed, str):
+    if not isinstance(allow_failed, str):
         return fallback_value
 
     if allow_failed.lower() not in ["true", "false"]:
@@ -141,7 +141,7 @@ def get_split_pdf_concurrency_level_param(
     """
     concurrency_level_str = form_data.get(key)
 
-    if concurrency_level_str is None or not isinstance(concurrency_level_str, str):
+    if not isinstance(concurrency_level_str, str):
         return fallback_value
 
     try:

--- a/src/unstructured_client/_hooks/custom/pdf_utils.py
+++ b/src/unstructured_client/_hooks/custom/pdf_utils.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import Generator, Tuple, Optional
+from typing import cast, Generator, Tuple, Optional
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.errors import PdfReadError
@@ -70,7 +70,8 @@ def is_pdf(file: shared.Files) -> bool:
         return False
 
     try:
-        PdfReader(io.BytesIO(file.content), strict=True)
+        content = cast(bytes, file.content)
+        PdfReader(io.BytesIO(content), strict=True)
     except (PdfReadError, UnicodeDecodeError) as exc:
         logger.error(exc)
         logger.warning("The file does not appear to be a valid PDF.")

--- a/src/unstructured_client/_hooks/custom/request_utils.py
+++ b/src/unstructured_client/_hooks/custom/request_utils.py
@@ -59,12 +59,13 @@ async def call_api_async(
 ) -> httpx.Response:
     page_content, page_number = page
     body = create_request_body(form_data, page_content, filename, page_number)
+    original_headers = prepare_request_headers(original_request.headers)
 
     new_request = httpx.Request(
         method="POST",
         url=original_request.url or "",
         content=body.to_string(),
-        headers={**original_request.headers, "Content-Type": body.content_type},
+        headers={**original_headers, "Content-Type": body.content_type},
     )
 
     async with limiter:
@@ -73,8 +74,8 @@ async def call_api_async(
 
 
 def prepare_request_headers(
-    headers: dict[str, str],
-) -> dict[str, str]:
+    headers: httpx.Headers,
+) -> httpx.Headers:
     """Prepare the request headers by removing the 'Content-Type' and 'Content-Length' headers.
 
     Args:
@@ -83,10 +84,10 @@ def prepare_request_headers(
     Returns:
         The modified request headers.
     """
-    headers = copy.deepcopy(headers)
-    headers.pop("Content-Type", None)
-    headers.pop("Content-Length", None)
-    return headers
+    new_headers = headers.copy()
+    new_headers.pop("Content-Type", None)
+    new_headers.pop("Content-Length", None)
+    return new_headers
 
 
 def prepare_request_payload(form_data: FormData) -> FormData:

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import io
-import json
 import logging
 import math
 from collections.abc import Awaitable
-from typing import Any, Coroutine, Optional, Tuple, Union
+from typing import Any, Coroutine, Optional, Tuple, Union, cast
 
 import httpx
-import nest_asyncio
-import requests
+import nest_asyncio  # type: ignore
 from pypdf import PdfReader
-from requests_toolbelt.multipart.decoder import MultipartDecoder
+from requests_toolbelt.multipart.decoder import MultipartDecoder  # type: ignore
 
 from unstructured_client._hooks.custom import form_utils, pdf_utils, request_utils
 from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_NAME
@@ -33,6 +31,7 @@ from unstructured_client._hooks.types import (
     BeforeRequestHook,
     SDKInitHook,
 )
+from unstructured_client.httpclient import HttpClient
 from unstructured_client.models import shared
 
 logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
@@ -45,12 +44,12 @@ MIN_PAGES_PER_SPLIT = 2
 MAX_PAGES_PER_SPLIT = 20
 
 
-async def _order_keeper(index: int, coro: Awaitable) -> Tuple[int, requests.Response]:
+async def _order_keeper(index: int, coro: Awaitable) -> Tuple[int, httpx.Response]:
     response = await coro
     return index, response
 
 
-async def run_tasks(coroutines: list[Awaitable], allow_failed: bool = False) -> list[tuple[int, requests.Response]]:
+async def run_tasks(coroutines: list[Coroutine], allow_failed: bool = False) -> list[tuple[int, httpx.Response]]:
     if allow_failed:
         responses = await asyncio.gather(*coroutines, return_exceptions=False)
         return list(enumerate(responses, 1))
@@ -103,25 +102,25 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
     """
 
     def __init__(self) -> None:
-        self.client: Optional[requests.Session] = None
+        self.client: Optional[HttpClient] = None
         self.coroutines_to_execute: dict[
-            str, list[Coroutine[Any, Any, requests.Response]]
+            str, list[Coroutine[Any, Any, httpx.Response]]
         ] = {}
-        self.api_successful_responses: dict[str, list[requests.Response]] = {}
-        self.api_failed_responses: dict[str, list[requests.Response]] = {}
+        self.api_successful_responses: dict[str, list[httpx.Response]] = {}
+        self.api_failed_responses: dict[str, list[httpx.Response]] = {}
         self.allow_failed: bool = DEFAULT_ALLOW_FAILED
 
     def sdk_init(
-            self, base_url: str, client: requests.Session
-    ) -> Tuple[str, requests.Session]:
+            self, base_url: str, client: HttpClient
+    ) -> Tuple[str, HttpClient]:
         """Initializes Split PDF Hook.
 
         Args:
             base_url (str): URL of the API.
-            client (requests.Session): HTTP Client.
+            client (HttpClient): HTTP Client.
 
         Returns:
-            Tuple[str, requests.Session]: The initialized SDK options.
+            Tuple[str, httpx.Session]: The initialized SDK options.
         """
         self.client = client
         return base_url, client
@@ -139,10 +138,10 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         Args:
             hook_ctx (BeforeRequestContext): The hook context containing information about
             the operation.
-            request (requests.PreparedRequest): The request object.
+            request (httpx.PreparedRequest): The request object.
 
         Returns:
-            Union[requests.PreparedRequest, Exception]: If `splitPdfPage` is set to `true`,
+            Union[httpx.PreparedRequest, Exception]: If `splitPdfPage` is set to `true`,
             the last page request; otherwise, the original request.
         """
         if self.client is None:
@@ -160,11 +159,11 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         content_type = request.headers.get("Content-Type")
 
         request_content = request.read()
-        body = request_content
-        if not isinstance(body, bytes) or content_type is None:
+        request_body = request_content
+        if not isinstance(request_body, bytes) or content_type is None:
             return request
 
-        decoded_body = MultipartDecoder(body, content_type)
+        decoded_body = MultipartDecoder(request_body, content_type)
         form_data = form_utils.parse_form_data(decoded_body)
         split_pdf_page = form_data.get(PARTITION_FORM_SPLIT_PDF_PAGE_KEY)
         if split_pdf_page is None or split_pdf_page == "false":
@@ -206,7 +205,8 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         logger.info("Concurrency level set to %d", concurrency_level)
         limiter = asyncio.Semaphore(concurrency_level)
 
-        pdf = PdfReader(io.BytesIO(file.content))
+        content = cast(bytes, file.content)
+        pdf = PdfReader(io.BytesIO(content))
 
         page_range_start, page_range_end = form_utils.get_page_range(
             form_data,
@@ -252,7 +252,7 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
 
         async def call_api_partial(page):
             async with httpx.AsyncClient() as client:
-                status_code, json_response = await request_utils.call_api_async(
+                response = await request_utils.call_api_async(
                     client=client,
                     original_request=request,
                     form_data=form_data,
@@ -261,14 +261,6 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
                     limiter=limiter,
                 )
 
-                # convert httpx response to requests.Response to preserve
-                # compatibility with the synchronous SDK generated by speakeasy
-                response = requests.Response()
-                response.status_code = status_code
-                response._content = json.dumps(  # pylint: disable=W0212
-                    json_response
-                ).encode()
-                response.headers["Content-Type"] = "application/json"
                 return response
 
         self.coroutines_to_execute[operation_id] = []
@@ -297,11 +289,19 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         body = request_utils.create_request_body(
             form_data, last_page_content, file.file_name, last_page_number
         )
-        last_page_request = request_utils.create_httpx_request(request, body)
+
+        original_request = request
+        last_page_request = httpx.Request(
+            method="POST",
+            url=original_request.url or "",
+            content=body.to_string(),
+            headers={**original_request.headers, "Content-Type": body.content_type},
+        )
+
         return last_page_request
 
     def _await_elements(
-            self, operation_id: str, response: requests.Response
+            self, operation_id: str, response: httpx.Response
     ) -> Optional[list]:
         """
         Waits for the partition requests to complete and returns the flattened
@@ -309,7 +309,7 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
 
         Args:
             operation_id (str): The ID of the operation.
-            response (requests.Response): The response object.
+            response (httpx.Response): The response object.
 
         Returns:
             Optional[list]: The flattened elements if the partition requests are
@@ -320,7 +320,8 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
             return None
 
         ioloop = asyncio.get_event_loop()
-        task_responses: list[tuple[int, requests.Response]] = ioloop.run_until_complete(
+        # TODO New response type
+        task_responses: list[tuple[int, httpx.Response]] = ioloop.run_until_complete(
             run_tasks(tasks, allow_failed=self.allow_failed)
         )
 
@@ -363,11 +364,11 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         Args:
             hook_ctx (AfterSuccessContext): The context object containing information
             about the hook execution.
-            response (requests.Response): The response object returned from the API
+            response (httpx.Response): The response object returned from the API
             request.
 
         Returns:
-            Union[requests.Response, Exception]: If requests were run in parallel, a
+            Union[httpx.Response, Exception]: If requests were run in parallel, a
             combined response object; otherwise, the original response. Can return
             exception if it ocurred during the execution.
         """
@@ -385,6 +386,8 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
 
         updated_response = request_utils.create_response(response, elements)
         self._clear_operation(operation_id)
+
+        # TODO
         return updated_response
 
     def after_error(
@@ -401,12 +404,12 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         Args:
             hook_ctx (AfterErrorContext): The AfterErrorContext object containing
             information about the hook context.
-            response (Optional[requests.Response]): The Response object representing
+            response (Optional[httpx.Response]): The Response object representing
             the response received before the exception occurred.
             error (Optional[Exception]): The exception object that was thrown.
 
         Returns:
-            Union[Tuple[Optional[requests.Response], Optional[Exception]], Exception]:
+            Union[Tuple[Optional[httpx.Response], Optional[Exception]], Exception]:
             If requests were run in parallel, and at least one was successful, a combined
             response object; otherwise, the original response and exception.
         """
@@ -418,7 +421,7 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         operation_id = hook_ctx.operation_id
         # We know that this request failed so we pass a failed or empty response to `_await_elements` method
         # where it checks if at least on of the other requests succeeded
-        elements = self._await_elements(operation_id, response or requests.Response())
+        elements = self._await_elements(operation_id, response or httpx.Response(status_code=200))
         successful_responses = self.api_successful_responses.get(operation_id)
 
         if elements is None or successful_responses is None:

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -14,6 +14,7 @@ from requests_toolbelt.multipart.decoder import MultipartDecoder  # type: ignore
 
 from unstructured_client._hooks.custom import form_utils, pdf_utils, request_utils
 from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_NAME
+from unstructured_client._hooks.custom.request_utils import prepare_request_headers
 from unstructured_client._hooks.custom.form_utils import (
     PARTITION_FORM_CONCURRENCY_LEVEL_KEY,
     PARTITION_FORM_FILES_KEY,
@@ -291,11 +292,12 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         )
 
         original_request = request
+        original_headers = prepare_request_headers(original_request.headers)
         last_page_request = httpx.Request(
             method="POST",
             url=original_request.url or "",
             content=body.to_string(),
-            headers={**original_request.headers, "Content-Type": body.content_type},
+            headers={**original_headers, "Content-Type": body.content_type},
         )
 
         return last_page_request

--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -320,7 +320,6 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
             return None
 
         ioloop = asyncio.get_event_loop()
-        # TODO New response type
         task_responses: list[tuple[int, httpx.Response]] = ioloop.run_until_complete(
             run_tasks(tasks, allow_failed=self.allow_failed)
         )
@@ -387,7 +386,6 @@ class SplitPdfHook(SDKInitHook, BeforeRequestHook, AfterSuccessHook, AfterErrorH
         updated_response = request_utils.create_response(response, elements)
         self._clear_operation(operation_id)
 
-        # TODO
         return updated_response
 
     def after_error(


### PR DESCRIPTION
Fix all mypy errors due to incorrect typing after the SDK v2 merge (https://github.com/Unstructured-IO/unstructured-python-client/pull/135). Logic changes should be minimal, this is mostly to change type hints where a `httpx.Response` is used instead of a `requests.Response`, etc. I removed some `form_utils.py` functions where we no longer need to convert a httpx request back to Requests. There's more we can cleanup in here, but let's get the V2 migration settled first.

Add mypy to `make lint` so that we can cath these errors before merging. The publish job runs a full linter suite, and these changes made it to main but broke the publish job.

Also, remove the Patch Custom Code step that I added to the generate. This broke the job. There are some minor changes to the Speakeasy code on the main branch. In the short term, this means we'll have to run `make patch-custom-code` whenever we regenerate.

# To verify
Make sure you can lint and run the tests locally. `make lint` and `make test`. You can also verify that the pdf split behavior has not changed with a call to your local server:
```
from unstructured_client import UnstructuredClient
from unstructured_client.models import shared, operations

import json

filename = "_sample_docs/layout-parser-paper.pdf"

s = UnstructuredClient(
    server_url="http://localhost:8000",
)

with open(filename, "rb") as f:
    files=shared.Files(
        content=f,
        file_name=filename,
    )

    req = operations.PartitionRequest(
        shared.PartitionParameters(
            files=files,
            strategy="fast",
            split_pdf_page_range=[4,8],
        ),
    )

    resp = s.general.partition(req)
    print(json.dumps(resp.elements, indent=4))
```