### PR TITLE
fix/ensure that split pdf requests are retried

### DIFF
--- a/_test_unstructured_client/integration/test_decorators.py
+++ b/_test_unstructured_client/integration/test_decorators.py
@@ -290,8 +290,7 @@ def test_split_pdf_requests_do_retry(monkeypatch):
     """
     Test that when we split a pdf, the split requests will honor retryable errors.
     """
-    # This is in a list so we can pass a reference to the mock function
-    number_of_502s = [1]
+    number_of_502s = 1
 
     async def mock_send(_, request):
         """
@@ -306,9 +305,10 @@ def test_split_pdf_requests_do_retry(monkeypatch):
         decoded_body = MultipartDecoder(request_body, request.headers.get("Content-Type"))
         form_data = form_utils.parse_form_data(decoded_body)
 
-        if number_of_502s[0] > 0:
+        nonlocal number_of_502s
+        if number_of_502s > 0:
             if "starting_page_number" in form_data and int(form_data["starting_page_number"]) < 3:
-                number_of_502s[0] -= 1
+                number_of_502s -= 1
                 return Response(502, request=request)
 
         mock_return_data = [{
@@ -348,5 +348,5 @@ def test_split_pdf_requests_do_retry(monkeypatch):
 
     res = sdk.general.partition(req)
 
-    assert number_of_502s[0] == 0
+    assert number_of_502s == 0
     assert res.status_code == 200

--- a/src/unstructured_client/_hooks/custom/request_utils.py
+++ b/src/unstructured_client/_hooks/custom/request_utils.py
@@ -19,6 +19,7 @@ from unstructured_client._hooks.custom.form_utils import (
     PARTITION_FORM_STARTING_PAGE_NUMBER_KEY,
     FormData,
 )
+import unstructured_client.utils as utils
 
 logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
 
@@ -69,8 +70,33 @@ async def call_api_async(
     )
 
     async with limiter:
-        response = await client.send(new_request)
+        response = await send_request_async_with_retries(client, new_request)
         return response
+
+
+async def send_request_async_with_retries(client: httpx.AsyncClient, request: httpx.Request):
+    retry_config = utils.RetryConfig(
+        "backoff",
+        utils.BackoffStrategy(2000, 60000, 1.5, 900000),
+        True
+    )
+
+    retryable_codes = [
+        "502",
+        "503",
+        "504"
+    ]
+
+    async def do_request():
+        return await client.send(request)
+
+    logger.error("Ready to retry")
+    response = await utils.retry_async(
+        do_request,
+        utils.Retries(retry_config, retryable_codes)
+    )
+
+    return response
 
 
 def prepare_request_headers(

--- a/src/unstructured_client/_hooks/custom/request_utils.py
+++ b/src/unstructured_client/_hooks/custom/request_utils.py
@@ -75,10 +75,18 @@ async def call_api_async(
 
 
 async def send_request_async_with_retries(client: httpx.AsyncClient, request: httpx.Request):
+    # Hardcode the retry config until we can
+    # properly reuse the SDK logic
+    # (Values are in ms)
     retry_config = utils.RetryConfig(
         "backoff",
-        utils.BackoffStrategy(2000, 60000, 1.5, 900000),
-        True
+        utils.BackoffStrategy(
+            initial_interval=2000,
+            max_interval=60000,
+            exponent=1.5,
+            max_elapsed_time=1000 * 60 * 5  # 5 minutes
+        ),
+        retry_connection_errors=True
     )
 
     retryable_codes = [

--- a/src/unstructured_client/_hooks/custom/request_utils.py
+++ b/src/unstructured_client/_hooks/custom/request_utils.py
@@ -90,7 +90,6 @@ async def send_request_async_with_retries(client: httpx.AsyncClient, request: ht
     async def do_request():
         return await client.send(request)
 
-    logger.error("Ready to retry")
     response = await utils.retry_async(
         do_request,
         utils.Retries(retry_config, retryable_codes)


### PR DESCRIPTION
We discovered that when a pdf is split into smaller chunks, those requests are not being retried. Now that we have `allow_failed=False`, this results in the whole document failing as soon as any of the child requests hit a transient error. The fix is to reuse the `utils.Retry` logic that the main code path uses. Copying the retry config in the hook logic is not great, and we can work with Speakeasy to make the internal logic more modular so we can reuse more. But for now, this will address the current failures while we work on a better implementation.

Testing:
See the added unit test. The existing retry logic works for the final split page, everything else needs to use the new logic. To test this, I mocked a response from the server to return 502 for a low `starting_page_number`, which we know will have to be handled by the hooks.

Other changes:
Remove the "Not splitting" log. When the final split page is retried, it triggers all the hooks again. We need to force `split_pdf_page=False` in this request, and we don't need additional logging when this code is hit again.