### PR TITLE
fix: Fix a mypy failure in the generate action

### DIFF
--- a/src/unstructured_client/_hooks/custom/split_pdf_hook.py
+++ b/src/unstructured_client/_hooks/custom/split_pdf_hook.py
@@ -76,7 +76,7 @@ async def run_tasks(coroutines: list[Coroutine], allow_failed: bool = False) -> 
 def context_is_uvloop():
     """Return true if uvloop is installed and we're currently in a uvloop context. Our asyncio splitting code currently doesn't work under uvloop."""
     try:
-        import uvloop  # pylint: disable=import-outside-toplevel  # type: ignore
+        import uvloop  # type: ignore[import]  # pylint: disable=import-outside-toplevel
         loop = asyncio.get_event_loop()
         return isinstance(loop, uvloop.Loop)
     except (ImportError, RuntimeError):


### PR DESCRIPTION
The `import uvloop` line here needs to:

* Ignore a pylint `import-outside-toplevel` warning
* Ignore a mypy error if stubs are not present (uvloop is not a dependency, so it's not actually installed in CI)

These comments were not ignoring both errors, turns out we need to flip the order.