### PR TITLE
Update request_utils.py

### DIFF
--- a/src/unstructured_client/_hooks/custom/request_utils.py
+++ b/src/unstructured_client/_hooks/custom/request_utils.py
@@ -81,10 +81,10 @@ async def send_request_async_with_retries(client: httpx.AsyncClient, request: ht
     retry_config = utils.RetryConfig(
         "backoff",
         utils.BackoffStrategy(
-            initial_interval=2000,
-            max_interval=60000,
-            exponent=1.5,
-            max_elapsed_time=1000 * 60 * 5  # 5 minutes
+            initial_interval=3000,  # 3 seconds
+            max_interval=1000 * 60 * 12,  # 12 minutes
+            exponent=1.88, 
+            max_elapsed_time=1000 * 60 * 30  # 30 minutes
         ),
         retry_connection_errors=True
     )


### PR DESCRIPTION
Tweak retry values to be more robust:

Should be equivalent to wait-time-values-between-retries and cumulative-time-between-tries of (in seconds):

```
>>> a = [min(math.floor(3 * (1.88 ** i)), 720) for i in range(10)]; a; [sum(a[:i+1]) for i in range(len(a))]
[3, 5, 10, 19, 37, 70, 132, 249, 468, 720]
[3, 8, 18, 37, 74, 144, 276, 525, 993, 1713]
```