### PR TITLE
chore: Set 0.26.0 version for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@
   <p>Python SDK for the Unstructured API</p>
 </h2>
 
-NOTE: This README is for the `0.26.0-beta` version. The current published SDK, `0.25.5` can be found [here](https://github.com/Unstructured-IO/unstructured-python-client/blob/v0.25.5/README.md).
-
 This is a Python client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/overview).
 
 Please refer to the [Unstructured docs](https://docs.unstructured.io/api-reference/api-services/sdk-python) for a full guide to using the client.

--- a/gen.yaml
+++ b/gen.yaml
@@ -10,7 +10,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 python:
-  version: 0.26.0-beta
+  version: 0.26.0
   additionalDependencies:
     dev: {}
     main:

--- a/src/unstructured_client/_hooks/custom/request_utils.py
+++ b/src/unstructured_client/_hooks/custom/request_utils.py
@@ -19,7 +19,7 @@ from unstructured_client._hooks.custom.form_utils import (
     PARTITION_FORM_STARTING_PAGE_NUMBER_KEY,
     FormData,
 )
-import unstructured_client.utils as utils
+from unstructured_client.utils import RetryConfig, retry_async, BackoffStrategy, Retries
 
 logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
 
@@ -78,9 +78,9 @@ async def send_request_async_with_retries(client: httpx.AsyncClient, request: ht
     # Hardcode the retry config until we can
     # properly reuse the SDK logic
     # (Values are in ms)
-    retry_config = utils.RetryConfig(
+    retry_config = RetryConfig(
         "backoff",
-        utils.BackoffStrategy(
+        BackoffStrategy(
             initial_interval=3000,  # 3 seconds
             max_interval=1000 * 60 * 12,  # 12 minutes
             exponent=1.88, 
@@ -98,9 +98,9 @@ async def send_request_async_with_retries(client: httpx.AsyncClient, request: ht
     async def do_request():
         return await client.send(request)
 
-    response = await utils.retry_async(
+    response = await retry_async(
         do_request,
-        utils.Retries(retry_config, retryable_codes)
+        Retries(retry_config, retryable_codes)
     )
 
     return response


### PR DESCRIPTION
Set the version in gen.yaml, to be picked up in the next generate/publish workflow. And fix an import that was flagged by pylint's `consider-using-from-import`

This is in order to release the split pdf retry fix. This will also push out the new `partition_async`, but we can follow up with docs/announcements later.