### PR TITLE
fix: raise httpx timeout value for split pdf requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
   merge_group:
     branches: [ main ]
 

--- a/gen.yaml
+++ b/gen.yaml
@@ -10,7 +10,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 python:
-  version: 0.25.6
+  version: 0.25.7
   additionalDependencies:
     dependencies:
       deepdiff: '>=6.0'


### PR DESCRIPTION
We're still seeing some ReadTimeout errors when a pdf is split and sent for `hi_res` processing. For now, let's raise the default timeout to 30 minutes, and allow for tweaking via the UNSTRUCTURED_CLIENT_TIMEOUT_MINUTES. Users should not generally need to adjust this, but it may help us debug their environment. When our split pdf hook is able to reuse the SDK logic, the client timeout will be exposed as a parameter, and we can remove this variable.

Other changes:
* Update CI workflow to run against release branches. This 0.25.x branch should be running tests as long as it sticks around.
* Bump the gen.yaml version to 0.25.7. The next generate/publish job on this branch will use this.