### PR TITLE
chore: Add min version requirement for `cryptography`

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -19,6 +19,7 @@ python:
       pytest-mock: '>=3.14.0'
       uvloop: '>=0.20.0'
     main:
+      cryptography: '>=3.1'
       httpx: '>=0.27.0'
       nest-asyncio: '>=1.6.0'
       pypdf: '>=4.0'

--- a/gen.yaml
+++ b/gen.yaml
@@ -14,7 +14,6 @@ python:
   additionalDependencies:
     dev:
       deepdiff: '>=6.0'
-      jupyter: '>=1.1.1'
       pytest: '>=8.3.3'
       pytest-asyncio: '>=0.24.0'
       pytest-mock: '>=3.14.0'


### PR DESCRIPTION
Bring the min version to the main branch - this is done for the 0.25.x release [here](https://github.com/Unstructured-IO/unstructured-python-client/pull/176).

Also, remove jupyter as a dev dependency. You're free to install it for local work, but we don't need to pull it on every `poetry install`. Case in point, it was causing an issue in the [generate action](https://github.com/Unstructured-IO/unstructured-python-client/actions/runs/10947329413/job/30395826215). The jupyter install was trying to pull in `psutil`, which needed to be built from source. However, our generate environment doesn't have all the build tools set up, so let's remove the need for `psutil` entirely.