### PR TITLE
feat: py 3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
   test_unit:
     strategy:
       matrix:
-        python-version: ["3.9","3.10","3.11"]
+        python-version: ["3.8", "3.9","3.10","3.11"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
   test_integration:
     strategy:
       matrix:
-        python-version: ["3.9","3.10","3.11"]
+        python-version: ["3.8", "3.9","3.10","3.11"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/_test_unstructured_client/integration/test_decorators.py
+++ b/_test_unstructured_client/integration/test_decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import httpx
 import json
 import pytest

--- a/_test_unstructured_client/integration/test_integration_freemium.py
+++ b/_test_unstructured_client/integration/test_integration_freemium.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/_test_unstructured_client/unit/test_custom_hooks.py
+++ b/_test_unstructured_client/unit/test_custom_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 

--- a/_test_unstructured_client/unit/test_split_pdf_hook.py
+++ b/_test_unstructured_client/unit/test_split_pdf_hook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import io
 import logging

--- a/src/unstructured_client/_hooks/custom/clean_server_url_hook.py
+++ b/src/unstructured_client/_hooks/custom/clean_server_url_hook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 from urllib.parse import ParseResult, urlparse, urlunparse
 

--- a/src/unstructured_client/_hooks/custom/form_utils.py
+++ b/src/unstructured_client/_hooks/custom/form_utils.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Union
+from typing import TYPE_CHECKING
 from typing_extensions import TypeAlias
 
 from requests_toolbelt.multipart.decoder import MultipartDecoder  # type: ignore
 
 from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_NAME
 from unstructured_client.models import shared
+
+if TYPE_CHECKING:
+    from typing import Union
 
 logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
 FormData: TypeAlias = "dict[str, Union[str, shared.Files, list[str]]]"

--- a/src/unstructured_client/_hooks/custom/form_utils.py
+++ b/src/unstructured_client/_hooks/custom/form_utils.py
@@ -10,7 +10,7 @@ from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_
 from unstructured_client.models import shared
 
 logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
-FormData: TypeAlias = dict[str, Union[str, shared.Files, list[str]]]
+FormData: TypeAlias = "dict[str, Union[str, shared.Files, list[str]]]"
 
 PARTITION_FORM_FILES_KEY = "files"
 PARTITION_FORM_SPLIT_PDF_PAGE_KEY = "split_pdf_page"

--- a/src/unstructured_client/_hooks/custom/form_utils.py
+++ b/src/unstructured_client/_hooks/custom/form_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Union
+from typing_extensions import TypeAlias
 
 from requests_toolbelt.multipart.decoder import MultipartDecoder  # type: ignore
 
@@ -9,7 +10,7 @@ from unstructured_client._hooks.custom.common import UNSTRUCTURED_CLIENT_LOGGER_
 from unstructured_client.models import shared
 
 logger = logging.getLogger(UNSTRUCTURED_CLIENT_LOGGER_NAME)
-FormData = dict[str, Union[str, shared.Files, list[str]]]
+FormData: TypeAlias = dict[str, Union[str, shared.Files, list[str]]]
 
 PARTITION_FORM_FILES_KEY = "files"
 PARTITION_FORM_SPLIT_PDF_PAGE_KEY = "split_pdf_page"
@@ -32,6 +33,7 @@ def get_page_range(form_data: FormData, key: str, max_pages: int) -> tuple[int, 
     Returns:
         The range of pages to send in the request in the form (start, end)
     """
+    _page_range = None
     try:
         _page_range = form_data.get(key)
 
@@ -202,7 +204,7 @@ def parse_form_data(decoded_data: MultipartDecoder) -> FormData:
     form_data: FormData = {}
 
     for part in decoded_data.parts:
-        content_disposition = part.headers.get(b"Content-Disposition")
+        content_disposition = part.headers.get(b"Content-Disposition") # type: ignore
         if content_disposition is None:
             raise RuntimeError("Content-Disposition header not found. Can't split pdf file.")
         part_params = decode_content_disposition(content_disposition)

--- a/src/unstructured_client/_hooks/custom/logger_hook.py
+++ b/src/unstructured_client/_hooks/custom/logger_hook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Optional, Tuple, Union, DefaultDict
 

--- a/src/unstructured_client/_hooks/custom/pdf_utils.py
+++ b/src/unstructured_client/_hooks/custom/pdf_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import logging
 from typing import cast, Generator, Tuple, Optional

--- a/src/unstructured_client/_hooks/custom/suggest_defining_url.py
+++ b/src/unstructured_client/_hooks/custom/suggest_defining_url.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple, Union
 
 import httpx


### PR DESCRIPTION
Adds `from __future__ import annotations` to all custom code files to enable forward references to contemporary type hints such as `dict` and ` list`. Also fixes a `TypeAlias` and enables python `3.8` checks (resolves https://github.com/Unstructured-IO/unstructured-python-client/issues/138)