### PR TITLE
fix: added missing dependencies to gen.yaml file

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -10,15 +10,17 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 python:
-  version: 0.27.0
+  version: 0.27.3
   additionalDependencies:
     dev:
       deepdiff: '>=6.0'
       pytest: '>=8.3.3'
       pytest-asyncio: '>=0.24.0'
       pytest-mock: '>=3.14.0'
+      types-aiofiles: '>=24.1.0'
       uvloop: '>=0.20.0'
     main:
+      aiofiles: '>=24.1.0'
       cryptography: '>=3.1'
       httpx: '>=0.27.0'
       nest-asyncio: '>=1.6.0'

--- a/gen.yaml
+++ b/gen.yaml
@@ -10,7 +10,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 python:
-  version: 0.27.3
+  version: 0.27.0
   additionalDependencies:
     dev:
       deepdiff: '>=6.0'


### PR DESCRIPTION
Adds `aiofiles` deps to `gen.yaml` file so they are not overwritten by the Generate workflow.