### PR TITLE
chore: Clean up some connector schemas in the overlay file

### DIFF
--- a/overlay_client.yaml
+++ b/overlay_client.yaml
@@ -70,3 +70,274 @@ actions:
     description: Add a null default to all optional parameters. Prevents the sdk from sending a default string when param is not specified.
     update:
         "default": null
+  - target: $["components"]["schemas"]["CreateSourceConnector"]["properties"]["config"]["anyOf"][7]["$ref"]
+    update: "#/components/schemas/GCSSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["CreateSourceConnector"]["properties"]["config"]["anyOf"][8]["$ref"]
+    update: "#/components/schemas/GoogleDriveSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["CreateSourceConnector"]["properties"]["config"]["anyOf"][9]["$ref"]
+    update: "#/components/schemas/KafkaCloudSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["CreateSourceConnector"]["properties"]["config"]["anyOf"][11]["$ref"]
+    update: "#/components/schemas/OneDriveSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]
+    update:
+      "GCSSourceConnectorConfig":
+        type: "object"
+        properties:
+          "remote_url":
+            type: "string"
+            title: "Remote Url"
+          "service_account_key":
+            type: "string"
+            title: "Service Account Key"
+        title: "GCSSourceConnectorConfig"
+        required:
+          - "remote_url"
+          - "service_account_key"
+  - target: $["components"]["schemas"]
+    update:
+      "GCSSourceConnectorConfigInput":
+        type: "object"
+        properties:
+          "remote_url":
+            type: "string"
+            title: "Remote Url"
+            pattern: "^(gs|gcs):\\/\\/"
+          "service_account_key":
+            type: "string"
+            title: "Service Account Key"
+        title: "GCSSourceConnectorConfigInput"
+        required:
+          - "remote_url"
+          - "service_account_key"
+  - target: $["components"]["schemas"]
+    update:
+      "GoogleDriveSourceConnectorConfig":
+        type: "object"
+        properties:
+          "drive_id":
+            type: "string"
+            title: "Drive Id"
+          "service_account_key":
+            type: "string"
+            title: "Service Account Key"
+          "extensions":
+            anyOf:
+              - type: "string"
+              - type: "null"
+            title: "Extensions"
+          "recursive":
+            type: "boolean"
+            title: "Recursive"
+        title: "GoogleDriveSourceConnectorConfig"
+        required:
+          - "drive_id"
+          - "service_account_key"
+          - "recursive"
+  - target: $["components"]["schemas"]
+    update:
+      "GoogleDriveSourceConnectorConfigInput":
+        type: "object"
+        properties:
+          "drive_id":
+            type: "string"
+            title: "Drive Id"
+          "service_account_key":
+            type: "string"
+            title: "Service Account Key"
+          "extensions":
+            anyOf:
+              - type: "string"
+              - type: "null"
+            title: "Extensions"
+          "recursive":
+            type: "boolean"
+            title: "Recursive"
+            default: true
+        title: "GoogleDriveSourceConnectorConfigInput"
+        required:
+          - "drive_id"
+          - "service_account_key"
+  - target: $["components"]["schemas"]
+    update:
+      "KafkaCloudSourceConnectorConfig":
+        type: "object"
+        properties:
+          "bootstrap_servers":
+            type: "string"
+            title: "Bootstrap Servers"
+          "port":
+            type: "integer"
+            title: "Port"
+          "group_id":
+            anyOf:
+              - type: "string"
+              - type: "null"
+            title: "Group Id"
+          "topic":
+            type: "string"
+            title: "Topic"
+          "kafka_api_key":
+            type: "string"
+            title: "Kafka Api Key"
+          "secret":
+            type: "string"
+            title: "Secret"
+          "num_messages_to_consume":
+            type: "integer"
+            title: "Num Messages To Consume"
+        title: "KafkaCloudSourceConnectorConfig"
+        required:
+          - "bootstrap_servers"
+          - "port"
+          - "topic"
+          - "kafka_api_key"
+          - "secret"
+          - "num_messages_to_consume"
+  - target: $["components"]["schemas"]
+    update:
+      "KafkaCloudSourceConnectorConfigInput":
+        type: "object"
+        properties:
+          "bootstrap_servers":
+            type: "string"
+            title: "Bootstrap Servers"
+          "port":
+            type: "integer"
+            title: "Port"
+            default: 9092
+          "group_id":
+            anyOf:
+              - type: "string"
+              - type: "null"
+            title: "Group Id"
+          "topic":
+            type: "string"
+            title: "Topic"
+          "kafka_api_key":
+            type: "string"
+            title: "Kafka Api Key"
+          "secret":
+            type: "string"
+            title: "Secret"
+          "num_messages_to_consume":
+            type: "integer"
+            title: "Num Messages To Consume"
+            default: 100
+        title: "KafkaCloudSourceConnectorConfigInput"
+        required:
+          - "bootstrap_servers"
+          - "topic"
+          - "kafka_api_key"
+          - "secret"
+  - target: $["components"]["schemas"]
+    update:
+      "OneDriveSourceConnectorConfig":
+        type: "object"
+        properties:
+          "client_id":
+            type: "string"
+            title: "Client Id"
+          "tenant":
+            type: "string"
+            title: "Tenant"
+          "authority_url":
+            type: "string"
+            title: "Authority Url"
+          "user_pname":
+            type: "string"
+            title: "User Pname"
+          "client_cred":
+            type: "string"
+            title: "Client Cred"
+          "recursive":
+            type: "boolean"
+            title: "Recursive"
+          "path":
+            type: "string"
+            title: "Path"
+        title: "OneDriveSourceConnectorConfig"
+        required:
+          - "client_id"
+          - "tenant"
+          - "authority_url"
+          - "user_pname"
+          - "client_cred"
+          - "recursive"
+          - "path"
+  - target: $["components"]["schemas"]
+    update:
+      "OneDriveSourceConnectorConfigInput":
+        type: "object"
+        properties:
+          "client_id":
+            type: "string"
+            title: "Client Id"
+          "tenant":
+            type: "string"
+            title: "Tenant"
+            default: "common"
+          "authority_url":
+            type: "string"
+            title: "Authority Url"
+            default: "https://login.microsoftonline.com"
+          "user_pname":
+            type: "string"
+            title: "User Pname"
+          "client_cred":
+            type: "string"
+            title: "Client Cred"
+          "recursive":
+            type: "boolean"
+            title: "Recursive"
+            default: false
+          "path":
+            type: "string"
+            title: "Path"
+        title: "OneDriveSourceConnectorConfigInput"
+        required:
+          - "client_id"
+          - "user_pname"
+          - "client_cred"
+          - "path"
+  - target: $["components"]["schemas"]["SourceConnectorInformation"]["properties"]["config"]["anyOf"][7]["$ref"]
+    update: "#/components/schemas/GCSSourceConnectorConfig"
+  - target: $["components"]["schemas"]["SourceConnectorInformation"]["properties"]["config"]["anyOf"][8]["$ref"]
+    update: "#/components/schemas/GoogleDriveSourceConnectorConfig"
+  - target: $["components"]["schemas"]["SourceConnectorInformation"]["properties"]["config"]["anyOf"][9]["$ref"]
+    update: "#/components/schemas/KafkaCloudSourceConnectorConfig"
+  - target: $["components"]["schemas"]["SourceConnectorInformation"]["properties"]["config"]["anyOf"][11]["$ref"]
+    update: "#/components/schemas/OneDriveSourceConnectorConfig"
+  - target: $["components"]["schemas"]["SourceConnectorType"]["enum"][9]
+    update: "kafka_cloud"
+  - target: $["components"]["schemas"]["UpdateSourceConnector"]["properties"]["config"]["anyOf"][7]["$ref"]
+    update: "#/components/schemas/GCSSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["UpdateSourceConnector"]["properties"]["config"]["anyOf"][8]["$ref"]
+    update: "#/components/schemas/GoogleDriveSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["UpdateSourceConnector"]["properties"]["config"]["anyOf"][9]["$ref"]
+    update: "#/components/schemas/KafkaCloudSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["UpdateSourceConnector"]["properties"]["config"]["anyOf"][11]["$ref"]
+    update: "#/components/schemas/OneDriveSourceConnectorConfigInput"
+  - target: $["components"]["schemas"]["GcsSourceConnectorConfig"]
+    remove: true
+  - target: $["components"]["schemas"]["GcsSourceConnectorConfigInput"]
+    remove: true
+  - target: $["components"]["schemas"]["Google_driveSourceConnectorConfig"]
+    remove: true
+  - target: $["components"]["schemas"]["Google_driveSourceConnectorConfigInput"]
+    remove: true
+  - target: $["components"]["schemas"]["Kafka-cloudSourceConnectorConfig"]
+    remove: true
+  - target: $["components"]["schemas"]["Kafka-cloudSourceConnectorConfigInput"]
+    remove: true
+  - target: $["components"]["schemas"]["OnedriveSourceConnectorConfig"]
+    remove: true
+  - target: $["components"]["schemas"]["OnedriveSourceConnectorConfigInput"]
+    remove: true
+  - target: $["components"]["schemas"]["CreateWorkflow"]["properties"]["workflow_nodes"]["anyOf"][0]["items"]["$ref"]
+    update: "#/components/schemas/WorkflowNode"
+  - target: $["components"]["schemas"]["UpdateWorkflow"]["properties"]["workflow_nodes"]["anyOf"][0]["items"]["$ref"]
+    update: "#/components/schemas/WorkflowNode"
+  - target: $["components"]["schemas"]["WorkflowNode"]["properties"]["id"]
+    remove: true
+  - target: $["components"]["schemas"]["CreateWorkflowNode"]
+    remove: true


### PR DESCRIPTION
This is to hold us over until these are updated on the backend. Add overlay config to remove existing schemas and recreate with a new name. This is a really ugly bandaid, we don't want to store actual schemas in this file for any longer than we have to.

Some tests are broken because we merged the schemas that we don't want, this should fix that on the next generate job.

Changes:

Onedrive -> OneDrive
Kafka-cloud -> KafkaCloud
gcs -> GCS
Google_drive -> GoogleDrive