### PR TITLE
fix cleaning urls

### DIFF
--- a/src/unstructured_client/_hooks/custom/clean_server_url_hook.py
+++ b/src/unstructured_client/_hooks/custom/clean_server_url_hook.py
@@ -24,7 +24,7 @@ def clean_server_url(base_url: str) -> str:
             parsed_url = parsed_url._replace(scheme="https")
 
     # We only want the base url
-    return urlunparse(parsed_url._replace(path="", params="", query="", fragment=""))
+    return urlunparse(parsed_url._replace(params="", query="", fragment=""))
 
 
 def choose_server_url(endpoint_url: str | None, client_url: str, default_endpoint_url: str) -> str:


### PR DESCRIPTION
Right now, if an API is hosted at a subpath, this will strip out the path.