### PR TITLE
feat: add a encrypt_secret helper function

### DIFF
--- a/_test_unstructured_client/unit/test_encryption.py
+++ b/_test_unstructured_client/unit/test_encryption.py
@@ -1,0 +1,128 @@
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+import os
+import base64
+from typing import Optional
+
+import pytest
+
+from unstructured_client import UnstructuredClient
+
+@pytest.fixture
+def rsa_key_pair():
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+    ).decode('utf-8')
+
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode('utf-8')
+
+    return private_key_pem, public_key_pem
+
+
+def decrypt_secret(
+    private_key_pem: str,
+    encrypted_value: str,
+    type: str,
+    encrypted_aes_key: str,
+    aes_iv: str,
+) -> str:
+    private_key = serialization.load_pem_private_key(
+        private_key_pem.encode('utf-8'),
+        password=None,
+        backend=default_backend()
+    )
+
+    if type == 'rsa':
+        ciphertext = base64.b64decode(encrypted_value)
+        plaintext = private_key.decrypt(
+            ciphertext,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
+            )
+        )
+        return plaintext.decode('utf-8')
+    else:
+        encrypted_aes_key = base64.b64decode(encrypted_aes_key)
+        iv = base64.b64decode(aes_iv)
+        ciphertext = base64.b64decode(encrypted_value)
+
+        aes_key = private_key.decrypt(
+            encrypted_aes_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
+            )
+        )
+        cipher = Cipher(
+            algorithms.AES(aes_key),
+            modes.CFB(iv),
+        )
+        decryptor = cipher.decryptor()
+        plaintext = decryptor.update(ciphertext) + decryptor.finalize()
+        return plaintext.decode('utf-8')
+
+
+def test_encrypt_rsa(rsa_key_pair):
+    private_key_pem, public_key_pem = rsa_key_pair
+
+    client = UnstructuredClient()
+
+    plaintext = "This is a secret message."
+
+    secret_obj = client.users.encrypt_secret(public_key_pem, plaintext)
+
+    # A short payload should use direct RSA encryption
+    assert secret_obj["type"] == 'rsa'
+
+    decrypted_text = decrypt_secret(
+        private_key_pem,
+        secret_obj["encrypted_value"],
+        secret_obj["type"],
+        "",
+        "",
+    )
+    assert decrypted_text == plaintext
+
+    assert True
+
+
+def test_encrypt_rsa_aes(rsa_key_pair):
+    private_key_pem, public_key_pem = rsa_key_pair
+
+    client = UnstructuredClient()
+
+    plaintext = "This is a secret message." * 100
+
+    secret_obj = client.users.encrypt_secret(public_key_pem, plaintext)
+
+    # A longer payload uses hybrid RSA-AES encryption
+    assert secret_obj["type"] == 'rsa_aes'
+
+    decrypted_text = decrypt_secret(
+        private_key_pem,
+        secret_obj["encrypted_value"],
+        secret_obj["type"],
+        secret_obj["encrypted_aes_key"],
+        secret_obj["aes_iv"],
+    )
+    assert decrypted_text == plaintext
+
+    assert True

--- a/_test_unstructured_client/unit/test_encryption.py
+++ b/_test_unstructured_client/unit/test_encryption.py
@@ -151,6 +151,5 @@ def test_encrypt_around_rsa_size_limit(rsa_key_pair, plaintext, secret_type):
 
     secret_obj = client.users.encrypt_secret(public_key_pem, plaintext)
 
-    # Should still use direct RSA encryption
     assert secret_obj["type"] == secret_type
     assert secret_obj["encrypted_value"] is not None

--- a/_test_unstructured_client/unit/test_encryption.py
+++ b/_test_unstructured_client/unit/test_encryption.py
@@ -101,8 +101,6 @@ def test_encrypt_rsa(rsa_key_pair):
     )
     assert decrypted_text == plaintext
 
-    assert True
-
 
 def test_encrypt_rsa_aes(rsa_key_pair):
     private_key_pem, public_key_pem = rsa_key_pair
@@ -124,5 +122,3 @@ def test_encrypt_rsa_aes(rsa_key_pair):
         secret_obj["aes_iv"],
     )
     assert decrypted_text == plaintext
-
-    assert True

--- a/gen.yaml
+++ b/gen.yaml
@@ -39,7 +39,7 @@ python:
   clientServerStatusCodesAsErrors: true
   defaultErrorName: SDKError
   description: Python Client SDK for Unstructured API
-  enableCustomCodeRegions: false
+  enableCustomCodeRegions: true
   enumFormat: enum
   fixFlags:
     responseRequiredSep2024: false

--- a/src/unstructured_client/users.py
+++ b/src/unstructured_client/users.py
@@ -548,7 +548,7 @@ class Users(BaseSDK):
             self,
             encryption_cert_or_key_pem: str,
             plaintext: str,
-            type: Optional[str] = None,
+            encryption_type: Optional[str] = None,
     ) -> dict:
         """
         Encrypts a plaintext string for securely sending to the Unstructured API.
@@ -581,11 +581,11 @@ class Users(BaseSDK):
         # If the plaintext is short, use RSA directly
         # Otherwise, use a RSA_AES envelope hybrid
         # The length of the public key is a good hueristic
-        if not type:
-            type = "rsa" if len(plaintext) <= len(public_key_pem) else "rsa_aes"
+        if not encryption_type:
+            encryption_type = "rsa" if len(plaintext) <= len(public_key_pem) else "rsa_aes"
 
-        if type == "rsa":
+        if encryption_type == "rsa":
             return self._encrypt_rsa(public_key_pem, plaintext)
-        else:
-            return self._encrypt_rsa_aes(public_key_pem, plaintext)
+
+        return self._encrypt_rsa_aes(public_key_pem, plaintext)
         # endregion sdk-class-body

--- a/src/unstructured_client/users.py
+++ b/src/unstructured_client/users.py
@@ -550,12 +550,12 @@ class Users(BaseSDK):
                 encryption_cert_or_key_pem.encode('utf-8'),
             )
 
-            public_key = cert.public_key()
+            public_key = cert.public_key()  # type: ignore[assignment]
         else:
             public_key = serialization.load_pem_public_key(
                 encryption_cert_or_key_pem.encode('utf-8'),
                 backend=default_backend()
-            ) 
+            )  # type: ignore[assignment]
 
         if not isinstance(public_key, rsa.RSAPublicKey):
             raise TypeError("Public key must be a RSA public key for encryption.")

--- a/src/unstructured_client/users.py
+++ b/src/unstructured_client/users.py
@@ -10,7 +10,6 @@ from unstructured_client.types import BaseModel, OptionalNullable, UNSET
 # region imports
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization, hashes
-from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
@@ -481,6 +480,9 @@ class Users(BaseSDK):
             backend=default_backend()
         )
 
+        if not isinstance(public_key, rsa.RSAPublicKey):
+            raise TypeError("Public key must be an RSA public key for envelope encryption.")
+
         # Generate a random AES key
         aes_key = os.urandom(32)  # 256-bit AES key
 
@@ -522,6 +524,9 @@ class Users(BaseSDK):
             encryption_key_pem.encode('utf-8'),
             backend=default_backend()
         )
+
+        if not isinstance(public_key, rsa.RSAPublicKey):
+            raise TypeError("Public key must be an RSA public key for encryption.")
 
         ciphertext = public_key.encrypt(
             plaintext.encode(),


### PR DESCRIPTION
Add a `users.encrypt_secret` that conforms to Unstructured's secret formats. This will allow users to encrypt credentials locally before using them in connector config.