### PR TITLE
feat: Enable arbitrary input for ConnectorType enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.42.2
+
+### Enhancements
+
+### Features
+* Enable arbitrary inputs for `SourceConnectorType` and `DestinationConnectorType`. This lets the client support new connector types without having to upgrade.
+
+### Fixes
+
+## 0.42.1
+
+### Enhancements
+
+### Features
+
+### Fixes
+* potential issue referencing models before declaration (commit by @mfbx9da4)
+
 ## 0.42.0
 
 ### Enhancements

--- a/gen.yaml
+++ b/gen.yaml
@@ -18,7 +18,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 python:
-  version: 0.42.1
+  version: 0.42.2
   additionalDependencies:
     dev:
       deepdiff: '>=6.0'

--- a/overlay_client.yaml
+++ b/overlay_client.yaml
@@ -77,3 +77,9 @@ actions:
   - target: $["components"]["schemas"]["partition_parameters"]["properties"]["tracking_enabled"]
     description: Remove tracking_enabled from partition_parameters
     remove: true
+  - target: $["components"]["schemas"]["SourceConnectorType"]
+    update:
+      "x-speakeasy-unknown-values": "allow"
+  - target: $["components"]["schemas"]["DestinationConnectorType"]
+    update:
+      "x-speakeasy-unknown-values": "allow"


### PR DESCRIPTION
Use the openapi overlay file to add `x-speakeasy-unknown-values` to the models for `SourceConnectorType` and `DestinationConnectorType`. This allows the client to send any string outside of the enum definitions. This provides forward compatibility in the client, we can create sources with types that don't exist yet, without requiring a new client version.

Example:

This throws an error that the type is not in our enum. Now, it just warns that this is an unknown value, but it's sent to the server anyway.

```
res = unstructured_client.sources.create_source(
    request={
        "create_source_connector": {
            "name": "My fancy new source",
            "type": "future_source_type",
            "config": {
                ...
                ...
            }
        }
    }
)
'''

The change will take effect when the client regenerates and uses the new overlay config. By setting
`gen.yaml` to `0.42.2`, the new client will propagate this version change.