### PR TITLE
fix: retry on RemoteProtocolError (server disconnect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.42.11
+
+### Enhancements
+
+### Features
+
+### Fixes
+* Retry on `httpx.RemoteProtocolError` (e.g. "Server disconnected without sending a response") when `retry_connection_errors=True`. Previously, mid-request server crashes were treated as permanent errors and not retried.
+
 ## 0.42.5
 
 ### Enhancements

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1191,3 +1191,13 @@ Based on:
 - [python v0.42.10] .
 ### Releases
 - [PyPI v0.42.10] https://pypi.org/project/unstructured-client/0.42.10 - .
+
+## 2026-03-25 16:00:00
+### Changes
+Based on:
+- OpenAPI Doc
+- Speakeasy CLI 1.601.0 (2.680.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v0.42.11] .
+### Releases
+- [PyPI v0.42.11] https://pypi.org/project/unstructured-client/0.42.11 - .

--- a/_test_unstructured_client/unit/test_retries.py
+++ b/_test_unstructured_client/unit/test_retries.py
@@ -1,0 +1,129 @@
+"""Tests for retry logic, specifically covering RemoteProtocolError retry behavior."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from unstructured_client.utils.retries import (
+    BackoffStrategy,
+    PermanentError,
+    Retries,
+    RetryConfig,
+    retry,
+    retry_async,
+)
+
+
+def _make_retries(retry_connection_errors: bool) -> Retries:
+    return Retries(
+        config=RetryConfig(
+            strategy="backoff",
+            backoff=BackoffStrategy(
+                initial_interval=100,
+                max_interval=200,
+                exponent=1.5,
+                max_elapsed_time=5000,
+            ),
+            retry_connection_errors=retry_connection_errors,
+        ),
+        status_codes=[],
+    )
+
+
+class TestRemoteProtocolErrorRetry:
+    """Test that RemoteProtocolError (e.g. 'Server disconnected without sending a response')
+    is retried when retry_connection_errors=True."""
+
+    def test_remote_protocol_error_retried_when_enabled(self):
+        """RemoteProtocolError should be retried and succeed on subsequent attempt."""
+        retries_config = _make_retries(retry_connection_errors=True)
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.RemoteProtocolError(
+                    "Server disconnected without sending a response."
+                )
+            return mock_response
+
+        result = retry(func, retries_config)
+        assert result.status_code == 200
+        assert call_count == 2
+
+    def test_remote_protocol_error_not_retried_when_disabled(self):
+        """RemoteProtocolError should raise PermanentError when retry_connection_errors=False."""
+        retries_config = _make_retries(retry_connection_errors=False)
+
+        def func():
+            raise httpx.RemoteProtocolError(
+                "Server disconnected without sending a response."
+            )
+
+        with pytest.raises(httpx.RemoteProtocolError):
+            retry(func, retries_config)
+
+    def test_connect_error_still_retried(self):
+        """Existing ConnectError retry behavior should be preserved."""
+        retries_config = _make_retries(retry_connection_errors=True)
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ConnectError("Connection refused")
+            return mock_response
+
+        result = retry(func, retries_config)
+        assert result.status_code == 200
+        assert call_count == 2
+
+
+class TestRemoteProtocolErrorRetryAsync:
+    """Async versions of the RemoteProtocolError retry tests."""
+
+    def test_remote_protocol_error_retried_async(self):
+        """Async: RemoteProtocolError should be retried when retry_connection_errors=True."""
+        retries_config = _make_retries(retry_connection_errors=True)
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+
+        call_count = 0
+
+        async def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.RemoteProtocolError(
+                    "Server disconnected without sending a response."
+                )
+            return mock_response
+
+        result = asyncio.run(retry_async(func, retries_config))
+        assert result.status_code == 200
+        assert call_count == 2
+
+    def test_remote_protocol_error_not_retried_async_when_disabled(self):
+        """Async: RemoteProtocolError should not be retried when retry_connection_errors=False."""
+        retries_config = _make_retries(retry_connection_errors=False)
+
+        async def func():
+            raise httpx.RemoteProtocolError(
+                "Server disconnected without sending a response."
+            )
+
+        with pytest.raises(httpx.RemoteProtocolError):
+            asyncio.run(retry_async(func, retries_config))

--- a/gen.yaml
+++ b/gen.yaml
@@ -23,7 +23,7 @@ generation:
   schemas:
     allOfMergeStrategy: shallowMerge
 python:
-  version: 0.42.10
+  version: 0.42.11
   additionalDependencies:
     dev:
       deepdiff: '>=6.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "unstructured-client"
-version = "0.42.10"
+version = "0.42.11"
 description = "Python Client SDK for Unstructured API"
 authors = [{ name = "Unstructured" },]
 readme = "README-PYPI.md"

--- a/src/unstructured_client/_version.py
+++ b/src/unstructured_client/_version.py
@@ -3,10 +3,10 @@
 import importlib.metadata
 
 __title__: str = "unstructured-client"
-__version__: str = "0.42.10"
+__version__: str = "0.42.11"
 __openapi_doc_version__: str = "1.2.31"
 __gen_version__: str = "2.680.0"
-__user_agent__: str = "speakeasy-sdk/python 0.42.10 2.680.0 1.2.31 unstructured-client"
+__user_agent__: str = "speakeasy-sdk/python 0.42.11 2.680.0 1.2.31 unstructured-client"
 
 try:
     if __package__ is not None:

--- a/src/unstructured_client/utils/retries.py
+++ b/src/unstructured_client/utils/retries.py
@@ -89,6 +89,11 @@ def retry(func, retries: Retries):
                     raise
 
                 raise PermanentError(exception) from exception
+            except httpx.RemoteProtocolError as exception:
+                if retries.config.retry_connection_errors:
+                    raise
+
+                raise PermanentError(exception) from exception
             except httpx.TimeoutException as exception:
                 if retries.config.retry_connection_errors:
                     raise
@@ -134,6 +139,11 @@ async def retry_async(func, retries: Retries):
                         if res.status_code == parsed_code:
                             raise TemporaryError(res)
             except httpx.ConnectError as exception:
+                if retries.config.retry_connection_errors:
+                    raise
+
+                raise PermanentError(exception) from exception
+            except httpx.RemoteProtocolError as exception:
                 if retries.config.retry_connection_errors:
                     raise
 


### PR DESCRIPTION
## Summary
- Adds `httpx.RemoteProtocolError` to the list of retriable exceptions in `retries.py` (both sync and async paths)
- When `retry_connection_errors=True`, server disconnects mid-request (e.g. "Server disconnected without sending a response") are now retried with backoff, matching the existing behavior for `ConnectError` and `TimeoutException`
- Previously, `RemoteProtocolError` fell through to the catch-all `Exception` handler and was wrapped as `PermanentError`, immediately failing without retry

## Context
When a server crashes mid-request (e.g. SIGSEGV from thread-unsafe native library access), the client receives an `httpx.RemoteProtocolError("Server disconnected without sending a response.")`. Despite `retry_connection_errors=True` being configured, this error was not retried because the SDK only handled `ConnectError` and `TimeoutException` as retriable transport errors.

The httpx exception hierarchy is:
```
RemoteProtocolError → ProtocolError → TransportError → RequestError → HTTPError
ConnectError → TransportError → RequestError → HTTPError  (already retried)
TimeoutException → TransportError → RequestError → HTTPError  (already retried)
```

`RemoteProtocolError` is the same class of transient transport error as the already-retried exceptions.

## Test plan
- [x] Added unit tests for sync and async retry paths
- [ ] `RemoteProtocolError` retried when `retry_connection_errors=True` — succeeds on 2nd attempt
- [ ] `RemoteProtocolError` raises immediately when `retry_connection_errors=False`
- [ ] Existing `ConnectError` retry behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry behavior for mid-request disconnects, which can increase duplicate-request risk for non-idempotent operations when `retry_connection_errors=True`. Scope is limited to transport-error handling and covered by new unit tests for sync/async paths.
> 
> **Overview**
> **Retries now treat `httpx.RemoteProtocolError` as a retriable transport failure** when `retry_connection_errors=True`, aligning it with existing `ConnectError`/`TimeoutException` handling in both `retry` and `retry_async`.
> 
> Adds unit tests validating the new sync/async retry behavior (and the disabled case), and bumps the SDK version to `0.42.11` with corresponding changelog/release entries and user-agent/version updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7dc972f0d6c8a2c3e75a26d2c2d7537e1d2df55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->