### PR TITLE
fix: correct RELEASES.md format for Speakeasy publish

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1195,7 +1195,7 @@ Based on:
 ## 2026-03-25 16:00:00
 ### Changes
 Based on:
-- OpenAPI Doc
+- OpenAPI Doc  
 - Speakeasy CLI 1.601.0 (2.680.0) https://github.com/speakeasy-api/speakeasy
 ### Generated
 - [python v0.42.11] .


### PR DESCRIPTION
## Summary
- Adds missing trailing spaces to `- OpenAPI Doc` line in the 0.42.11 RELEASES.md entry
- Adds missing trailing newline at end of file
- The Speakeasy publish action failed with `error parsing last release info` because the format didn't match the expected pattern

This unblocks the 0.42.11 PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only formatting tweaks (trailing spaces/newline) to satisfy Speakeasy release parsing; no runtime code changes.
> 
> **Overview**
> Fixes the `2026-03-25` (`v0.42.11`) entry in `RELEASES.md` to match Speakeasy’s expected release format by restoring the trailing spaces on `- OpenAPI Doc` and ensuring the file ends with a proper final newline (so the last `PyPI v0.42.11` line is parsed correctly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39fd2ae933b7a9e0403fdd99395428a858b90323. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->