### PR TITLE
chore: improve visz on 504: Error in partition - {"error": "Connection error while initiating          partition request from unstructured_client", "message": "", "type": "partition_connection_error"}

### DIFF
--- a/src/unstructured_client/_version.py
+++ b/src/unstructured_client/_version.py
@@ -3,7 +3,7 @@
 import importlib.metadata
 
 __title__: str = "unstructured-client"
-__version__: str = "0.43.2"
+__version__: str = "0.43.3"
 __openapi_doc_version__: str = "1.2.31"
 __gen_version__: str = "2.680.0"
 __user_agent__: str = "speakeasy-sdk/python 0.43.2 2.680.0 1.2.31 unstructured-client"

--- a/src/unstructured_client/_version.py
+++ b/src/unstructured_client/_version.py
@@ -6,7 +6,7 @@ __title__: str = "unstructured-client"
 __version__: str = "0.43.3"
 __openapi_doc_version__: str = "1.2.31"
 __gen_version__: str = "2.680.0"
-__user_agent__: str = "speakeasy-sdk/python 0.43.2 2.680.0 1.2.31 unstructured-client"
+__user_agent__: str = "speakeasy-sdk/python 0.43.3 2.680.0 1.2.31 unstructured-client"
 
 try:
     if __package__ is not None:

--- a/src/unstructured_client/utils/retries.py
+++ b/src/unstructured_client/utils/retries.py
@@ -172,7 +172,11 @@ def retry_with_backoff(
                 if isinstance(exception, TemporaryError):
                     return exception.response
 
-                raise
+                elapsed_seconds = (now - start) / 1000
+                raise type(exception)(
+                    f"{type(exception).__name__} after {retries + 1} retries "
+                    f"over {elapsed_seconds:.1f}s: {exception}"
+                ) from exception
             sleep = (initial_interval / 1000) * exponent**retries + random.uniform(0, 1)
             sleep = min(sleep, max_interval / 1000)
             time.sleep(sleep)
@@ -200,7 +204,11 @@ async def retry_with_backoff_async(
                 if isinstance(exception, TemporaryError):
                     return exception.response
 
-                raise
+                elapsed_seconds = (now - start) / 1000
+                raise type(exception)(
+                    f"{type(exception).__name__} after {retries + 1} retries "
+                    f"over {elapsed_seconds:.1f}s: {exception}"
+                ) from exception
             sleep = (initial_interval / 1000) * exponent**retries + random.uniform(0, 1)
             sleep = min(sleep, max_interval / 1000)
             await asyncio.sleep(sleep)

--- a/src/unstructured_client/utils/retries.py
+++ b/src/unstructured_client/utils/retries.py
@@ -174,7 +174,7 @@ def retry_with_backoff(
 
                 elapsed_seconds = (now - start) / 1000
                 raise type(exception)(
-                    f"{type(exception).__name__} after {retries + 1} retries "
+                    f"{type(exception).__name__} after {retries + 1} attempts "
                     f"over {elapsed_seconds:.1f}s: {exception}"
                 ) from exception
             sleep = (initial_interval / 1000) * exponent**retries + random.uniform(0, 1)
@@ -206,7 +206,7 @@ async def retry_with_backoff_async(
 
                 elapsed_seconds = (now - start) / 1000
                 raise type(exception)(
-                    f"{type(exception).__name__} after {retries + 1} retries "
+                    f"{type(exception).__name__} after {retries + 1} attempts "
                     f"over {elapsed_seconds:.1f}s: {exception}"
                 ) from exception
             sleep = (initial_interval / 1000) * exponent**retries + random.uniform(0, 1)


### PR DESCRIPTION
504: Error in partition - {"error": "Connection error while initiating         
partition request from unstructured_client", "message": "", "type": "partition_connection_error"}


change: "ReadError after 5 retries over 312.4s" instead of "message": ""

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior only changes error formatting/raising when the backoff budget is exhausted; normal retry and success paths are unchanged.
> 
> **Overview**
> Improves observability when retries exceed `max_elapsed_time` by rethrowing the original exception type with a message that includes the number of attempts and total elapsed time (sync and async backoff paths), while preserving the original exception via chaining.
> 
> Bumps the generated SDK version/user-agent from `0.43.2` to `0.43.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400e8e532de1b859f0bc0f412a279e35b618e0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->