### PR TITLE
feat(retries): add min_attempts and absolute_max_elapsed_time_ms to BackoffStrategy

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -19,3 +19,16 @@ src/unstructured_client/users.py
 #  - Adjust the custom url snippets in the file
 #  - Bring back the ignore line and commit
 src/unstructured_client/general.py
+
+# Ignore retries.py so we can carry the `min_attempts` and
+# `absolute_max_elapsed_time_ms` fields on BackoffStrategy plus the
+# soft/hard cap logic in retry_with_backoff{,_async}. Filed in FS-1988.
+# Speakeasy regen would otherwise wipe these fields. To pick up upstream
+# fixes to the generated retry runtime:
+#  - Comment out this ignore line
+#  - Generate locally
+#  - Manually re-merge the FS-1988 additions
+#  - Re-add the ignore line and commit
+# Long-term: push these fields upstream to Speakeasy templates so this
+# ignore can be removed.
+src/unstructured_client/utils/retries.py

--- a/.genignore
+++ b/.genignore
@@ -20,15 +20,6 @@ src/unstructured_client/users.py
 #  - Bring back the ignore line and commit
 src/unstructured_client/general.py
 
-# Ignore retries.py so we can carry the `min_attempts` and
-# `absolute_max_elapsed_time_ms` fields on BackoffStrategy plus the
-# soft/hard cap logic in retry_with_backoff{,_async}. Filed in FS-1988.
-# Speakeasy regen would otherwise wipe these fields. To pick up upstream
-# fixes to the generated retry runtime:
-#  - Comment out this ignore line
-#  - Generate locally
-#  - Manually re-merge the FS-1988 additions
-#  - Re-add the ignore line and commit
-# Long-term: push these fields upstream to Speakeasy templates so this
-# ignore can be removed.
+# Custom min_attempts / absolute_max_elapsed_time_ms fields on BackoffStrategy
+# (FS-1988). Push upstream to Speakeasy templates to remove this entry.
 src/unstructured_client/utils/retries.py

--- a/.genignore
+++ b/.genignore
@@ -20,6 +20,6 @@ src/unstructured_client/users.py
 #  - Bring back the ignore line and commit
 src/unstructured_client/general.py
 
-# Custom min_attempts / absolute_max_elapsed_time_ms fields on BackoffStrategy
-# (FS-1988). Push upstream to Speakeasy templates to remove this entry.
+# Custom min_attempts / absolute_max_elapsed_time_ms fields on BackoffStrategy.
+# Push upstream to Speakeasy templates to remove this entry.
 src/unstructured_client/utils/retries.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Breaking changes
 * Removed deprecated connector config models from the SDK (e.g. `S3SourceConnectorConfig`, `AzureDestinationConnectorConfig`). Pass connector configs as plain dicts with arbitrary fields. The SDK is no longer coupled to backend connector schemas — new fields work without an SDK upgrade.
 
+### Features
+* Add `min_attempts` and `absolute_max_elapsed_time_ms` fields to `BackoffStrategy`. `min_attempts` is the minimum number of retry attempts that must fire before `max_elapsed_time` is honored; defaults to `0` (preserves existing behavior). `absolute_max_elapsed_time_ms` caps when a new retry can start (does not interrupt in-flight requests); defaults to `None`. Together these close a short-circuit where a single slow first attempt could exhaust the retry budget before any retry fired. See FS-1988.
+
 ## 0.43.4
 
 ### Enhancements

--- a/_test_unstructured_client/integration/test_decorators.py
+++ b/_test_unstructured_client/integration/test_decorators.py
@@ -813,3 +813,79 @@ async def test_split_pdf_transport_errors_still_retry_when_sdk_disables_connecti
     assert number_of_transport_failures == 0
     assert mock_endpoint_called
     assert res.status_code == 200
+
+
+def test_split_pdf_cache_tmp_data_chunk_request_stream_is_replay_safe(tmp_path):
+    """Regression test for FS-1988: when split_pdf_cache_tmp_data=True
+    is set, chunks are loaded as opened file objects (not BytesIO) and
+    handed to `create_pdf_chunk_request`. The resulting `httpx.Request`
+    must be replay-safe — i.e. its body stream can be iterated more
+    than once, returning identical bytes each time.
+
+    Body replay is what makes SDK-level retries on transient errors
+    (ReadTimeout, ConnectError, etc.) actually deliver the original
+    multipart payload to the server. A future Speakeasy template
+    change or refactor of `serialize_request_body` that produced a
+    single-consumption stream (e.g. an `Iterable[bytes]` over an open
+    file handle) would silently break retries: the server would see
+    an empty body on the second attempt.
+
+    The invariant is pinned by iterating `request.stream` twice
+    directly — NOT via `request.read()`, which caches into
+    `Request._content` and would paper over a non-replayable stream
+    after the first call. This is the actual transport-level path
+    httpcore uses when `AsyncClient.send` retries a request.
+    """
+    from unstructured_client._hooks.custom.request_utils import (
+        create_pdf_chunk_request,
+    )
+
+    # Drive `create_pdf_chunk_request` directly with a file-object
+    # chunk — the cache_tmp_data=True branch in `_get_pdf_chunk_files`.
+    chunk_path = tmp_path / "chunk.pdf"
+    src_bytes = Path("_sample_docs/layout-parser-paper.pdf").read_bytes()
+    chunk_path.write_bytes(src_bytes)
+
+    pdf_chunk_file = open(chunk_path, "rb")  # noqa: SIM115 -- closed manually
+    try:
+        form_data = {
+            "files": (chunk_path.name, src_bytes, "application/pdf"),
+            "strategy": "fast",
+        }
+        original_request = httpx.Request(
+            method="POST",
+            url="http://localhost:8000/general/v0/general",
+            headers={
+                "Content-Type": "multipart/form-data; boundary=test",
+                "User-Agent": "test",
+            },
+            content=b"",
+        )
+
+        chunk_request = create_pdf_chunk_request(
+            form_data=form_data,
+            pdf_chunk=(pdf_chunk_file, 1),
+            original_request=original_request,
+            filename=chunk_path.name,
+        )
+
+        # Iterate the body stream twice. If the underlying stream is
+        # not replayable (e.g. an open file handle that's exhausted
+        # after the first pass), the second iteration yields empty
+        # or partial bytes and the assert below fails.
+        first_pass = b"".join(chunk_request.stream)
+        second_pass = b"".join(chunk_request.stream)
+
+        assert len(first_pass) > 1000, (
+            f"First iteration produced too-small body ({len(first_pass)} "
+            "bytes); a real PDF chunk multipart envelope should be at "
+            "least kilobytes."
+        )
+        assert first_pass == second_pass, (
+            "Body stream not replay-safe: second iteration of "
+            "chunk_request.stream returned different bytes than the "
+            "first. SDK retries on transient errors would silently "
+            "send a truncated or empty body to the server."
+        )
+    finally:
+        pdf_chunk_file.close()

--- a/_test_unstructured_client/integration/test_decorators.py
+++ b/_test_unstructured_client/integration/test_decorators.py
@@ -816,37 +816,15 @@ async def test_split_pdf_transport_errors_still_retry_when_sdk_disables_connecti
 
 
 def test_split_pdf_cache_tmp_data_chunk_request_stream_is_replay_safe(tmp_path):
-    """Regression test for FS-1988: when split_pdf_cache_tmp_data=True
-    is set, chunks are loaded as opened file objects (not BytesIO) and
-    handed to `create_pdf_chunk_request`. The resulting `httpx.Request`
-    must be replay-safe — i.e. its body stream can be iterated more
-    than once, returning identical bytes each time.
-
-    Body replay is what makes SDK-level retries on transient errors
-    (ReadTimeout, ConnectError, etc.) actually deliver the original
-    multipart payload to the server. A future Speakeasy template
-    change or refactor of `serialize_request_body` that produced a
-    single-consumption stream (e.g. an `Iterable[bytes]` over an open
-    file handle) would silently break retries: the server would see
-    an empty body on the second attempt.
-
-    The invariant is pinned by iterating `request.stream` twice
-    directly — NOT via `request.read()`, which caches into
-    `Request._content` and would paper over a non-replayable stream
-    after the first call. This is the actual transport-level path
-    httpcore uses when `AsyncClient.send` retries a request.
-    """
     from unstructured_client._hooks.custom.request_utils import (
         create_pdf_chunk_request,
     )
 
-    # Drive `create_pdf_chunk_request` directly with a file-object
-    # chunk — the cache_tmp_data=True branch in `_get_pdf_chunk_files`.
     chunk_path = tmp_path / "chunk.pdf"
     src_bytes = Path("_sample_docs/layout-parser-paper.pdf").read_bytes()
     chunk_path.write_bytes(src_bytes)
 
-    pdf_chunk_file = open(chunk_path, "rb")  # noqa: SIM115 -- closed manually
+    pdf_chunk_file = open(chunk_path, "rb")  # noqa: SIM115
     try:
         form_data = {
             "files": (chunk_path.name, src_bytes, "application/pdf"),
@@ -869,23 +847,11 @@ def test_split_pdf_cache_tmp_data_chunk_request_stream_is_replay_safe(tmp_path):
             filename=chunk_path.name,
         )
 
-        # Iterate the body stream twice. If the underlying stream is
-        # not replayable (e.g. an open file handle that's exhausted
-        # after the first pass), the second iteration yields empty
-        # or partial bytes and the assert below fails.
+        # Iterate twice without request.read() to bypass _content caching.
         first_pass = b"".join(chunk_request.stream)
         second_pass = b"".join(chunk_request.stream)
 
-        assert len(first_pass) > 1000, (
-            f"First iteration produced too-small body ({len(first_pass)} "
-            "bytes); a real PDF chunk multipart envelope should be at "
-            "least kilobytes."
-        )
-        assert first_pass == second_pass, (
-            "Body stream not replay-safe: second iteration of "
-            "chunk_request.stream returned different bytes than the "
-            "first. SDK retries on transient errors would silently "
-            "send a truncated or empty body to the server."
-        )
+        assert len(first_pass) > 1000
+        assert first_pass == second_pass
     finally:
         pdf_chunk_file.close()

--- a/_test_unstructured_client/unit/test_retries.py
+++ b/_test_unstructured_client/unit/test_retries.py
@@ -1,6 +1,3 @@
-"""Tests for retry logic covering all TransportError subclasses
-and the FS-1988 min_attempts / absolute_max_elapsed_time_ms semantics."""
-
 import asyncio
 import time as time_module
 from unittest.mock import MagicMock
@@ -20,29 +17,7 @@ from unstructured_client.utils.retries import (
 )
 
 
-# -----------------------------------------------------------------
-# FS-1988 fake-clock harness
-#
-# `retries.py` reads `time.time()` and calls `time.sleep()` /
-# `asyncio.sleep()`. The retries module imports `time` and `asyncio`
-# at module scope, so we patch those module attributes. Each test
-# starts the clock at 0ms and advances it explicitly:
-#   - `time.sleep(s)` advances the fake clock by s*1000 ms
-#   - `asyncio.sleep(s)` advances the fake clock by s*1000 ms
-#   - the test `func` callable advances the clock by its own simulated
-#     attempt duration before raising / returning
-# -----------------------------------------------------------------
-
-
 class FakeClock:
-    """Mutable monotonic clock for retry loop tests.
-
-    Tracks elapsed milliseconds since fixture creation. `now_ms` is
-    incremented by patched sleep functions and by test func() bodies.
-    `time()` returns a float seconds value compatible with
-    `round(time.time() * 1000)` patterns in retries.py.
-    """
-
     def __init__(self):
         self.now_ms = 0
 
@@ -69,10 +44,7 @@ def fake_clock(monkeypatch):
     monkeypatch.setattr(retries_module.time, "time", fake_time)
     monkeypatch.setattr(retries_module.time, "sleep", fake_sync_sleep)
     monkeypatch.setattr(retries_module.asyncio, "sleep", fake_async_sleep)
-    # Strip jitter so backoff durations are exactly reproducible.
-    monkeypatch.setattr(
-        retries_module.random, "uniform", lambda a, b: 0.0
-    )
+    monkeypatch.setattr(retries_module.random, "uniform", lambda a, b: 0.0)
     return clock
 
 
@@ -126,7 +98,6 @@ def _make_retries(retry_connection_errors: bool) -> Retries:
     )
 
 
-# All TransportError subclasses that should be retried
 TRANSPORT_ERRORS = [
     (httpx.ConnectError, "Connection refused"),
     (httpx.RemoteProtocolError, "Server disconnected without sending a response."),
@@ -138,7 +109,6 @@ TRANSPORT_ERRORS = [
 
 
 class TestTransportErrorRetry:
-    """All httpx.TransportError subclasses should be retried when retry_connection_errors=True."""
 
     @pytest.mark.parametrize("exc_class,msg", TRANSPORT_ERRORS)
     def test_transport_error_retried_when_enabled(self, exc_class, msg):
@@ -172,7 +142,6 @@ class TestTransportErrorRetry:
 
 
 class TestTransportErrorRetryAsync:
-    """Async: All httpx.TransportError subclasses should be retried."""
 
     @pytest.mark.parametrize("exc_class,msg", TRANSPORT_ERRORS)
     def test_transport_error_retried_async(self, exc_class, msg):
@@ -203,12 +172,6 @@ class TestTransportErrorRetryAsync:
 
         with pytest.raises(exc_class):
             asyncio.run(retry_async(func, retries_config))
-
-
-# -----------------------------------------------------------------
-# FS-1988 tests: BackoffStrategy validation (T12-T14)
-# These do not need the fake-clock harness.
-# -----------------------------------------------------------------
 
 
 class TestBackoffStrategyValidation:
@@ -262,11 +225,6 @@ class TestBackoffStrategyValidation:
             max_elapsed_time=5_000,
             absolute_max_elapsed_time_ms=5_000,
         )
-
-
-# -----------------------------------------------------------------
-# FS-1988 tests: T1, T2 -- backward compatibility (min_attempts=0)
-# -----------------------------------------------------------------
 
 
 class TestBackwardCompat:
@@ -327,16 +285,8 @@ class TestBackwardCompat:
         assert call_count == 2
 
 
-# -----------------------------------------------------------------
-# FS-1988 tests: T3 -- the v1 reproducer.
-# Attempt 1 takes longer than the soft cap; the min_attempts floor
-# must permit attempt 2 to fire, which then succeeds.
-# -----------------------------------------------------------------
-
-
 class TestSoftCapFloor:
     def test_t3_slow_first_attempt_then_success_sync(self, fake_clock):
-        # Soft cap 5s, attempt 1 takes 6s, min_attempts=2.
         retries_config = _retries(
             max_elapsed_time=5_000,
             min_attempts=2,
@@ -375,9 +325,6 @@ class TestSoftCapFloor:
         assert call_count == 2
 
     def test_t3_baseline_pre_fix_behavior(self, fake_clock):
-        """Without the min_attempts floor (min_attempts=0), the same
-        scenario short-circuits with no retries -- this is the pre-fix
-        regression. Documents the bug class we are closing."""
         retries_config = _retries(
             max_elapsed_time=5_000,
             min_attempts=0,
@@ -399,15 +346,8 @@ class TestSoftCapFloor:
         assert call_count == 1
 
 
-# -----------------------------------------------------------------
-# FS-1988 tests: T4, T5 -- floor is NOT a ceiling.
-# -----------------------------------------------------------------
-
-
 class TestFloorIsNotCeiling:
     def test_t4_floor_does_not_cap_attempts_sync(self, fake_clock):
-        """min_attempts=2 with 5 transient failures + budget should
-        produce 6 total attempts, NOT 3."""
         retries_config = _retries(
             initial_interval=100,
             max_interval=200,
@@ -429,9 +369,6 @@ class TestFloorIsNotCeiling:
         assert call_count == 6
 
     def test_t5_floor_then_soft_cap_sync(self, fake_clock):
-        """With min_attempts=2 and all attempts failing fast, the
-        loop must fire AT LEAST 3 total attempts (initial + 2 retries)
-        before the soft cap can cut in."""
         retries_config = _retries(
             initial_interval=100,
             max_interval=200,
@@ -444,26 +381,16 @@ class TestFloorIsNotCeiling:
         def func():
             nonlocal call_count
             call_count += 1
-            # Each attempt itself is instantaneous; only the backoff
             # sleep advances the fake clock.
             raise httpx.ConnectError("transient")
 
         with pytest.raises(httpx.ConnectError):
             retry(func, retries_config)
-        # 3 = initial + 2 retries (the min_attempts floor)
         assert call_count >= 3
-
-
-# -----------------------------------------------------------------
-# FS-1988 tests: T6, T7 -- hard cap overrides the floor; sleep
-# truncation prevents sleeping into a doomed retry.
-# -----------------------------------------------------------------
 
 
 class TestHardCap:
     def test_t6_hard_cap_overrides_floor_sync(self, fake_clock):
-        """min_attempts=2 but attempt 1 takes longer than the hard
-        cap. Hard cap must fire even though the floor is unsatisfied."""
         retries_config = _retries(
             max_elapsed_time=5_000,
             min_attempts=2,
@@ -481,7 +408,6 @@ class TestHardCap:
 
         with pytest.raises(httpx.ReadTimeout):
             retry(func, retries_config)
-        # Hard cap fires after attempt 1; no further attempts.
         assert call_count == 1
 
     def test_t6_hard_cap_overrides_floor_async(self, fake_clock):
@@ -505,10 +431,6 @@ class TestHardCap:
         assert call_count == 1
 
     def test_t7_sleep_truncation_prevents_doomed_retry_sync(self, fake_clock):
-        """Hard cap pre-emptive check: if the sleep alone would push
-        past the cap, raise immediately rather than sleeping into a
-        retry that can never start."""
-        # Soft cap 5s, hard cap 10s, attempt 1 takes 9.95s.
         # Sleep starts at 100ms * 1.5^0 = 100ms (no jitter in tests),
         # but we want to assert the sleep+elapsed > hard_cap path
         # fires. Use larger initial_interval to make the calculation
@@ -538,16 +460,8 @@ class TestHardCap:
         assert call_count == 1
 
 
-# -----------------------------------------------------------------
-# FS-1988 tests: T8, T9, T10 -- TemporaryError (retryable 5xx)
-# early-return behavior under soft and hard cap exhaustion.
-# -----------------------------------------------------------------
-
-
 class TestTemporaryErrorEarlyReturn:
     def test_t8_soft_cap_5xx_returns_last_response_sync(self, fake_clock):
-        """min_attempts=0, retryable 5xx, soft cap exhausted: returns
-        the last 5xx response (existing behavior)."""
         retries_config = _retries(
             initial_interval=100,
             max_interval=200,
@@ -562,11 +476,9 @@ class TestTemporaryErrorEarlyReturn:
         def func():
             nonlocal call_count
             call_count += 1
-            # Each attempt itself is instant; backoff sleep accumulates.
             return bad_response
 
         result = retry(func, retries_config)
-        # Should return the last 5xx response, not raise.
         assert result.status_code == 503
         assert call_count >= 1
 
@@ -589,12 +501,9 @@ class TestTemporaryErrorEarlyReturn:
 
         result = retry(func, retries_config)
         assert result.status_code == 503
-        # Floor enforced: at least initial + 2 retries before soft cap.
         assert call_count >= 3
 
     def test_t10_hard_cap_5xx_returns_last_response_sync(self, fake_clock):
-        """Hard cap fires; TemporaryError still returns the response,
-        not a raised exception."""
         retries_config = _retries(
             initial_interval=100,
             max_interval=200,
@@ -619,18 +528,7 @@ class TestTemporaryErrorEarlyReturn:
         assert call_count == 1
 
 
-# -----------------------------------------------------------------
-# FS-1988 tests: T11 -- PermanentError unaffected by min_attempts.
-# -----------------------------------------------------------------
-
-
 class TestPermanentErrorShortCircuit:
-    """A non-transport, non-status-code exception raised from func() is
-    wrapped by retry/retry_async's inner do_request closure in a
-    PermanentError. The outer retry_with_backoff{,_async} catches
-    PermanentError and re-raises `.inner`, which short-circuits the loop
-    regardless of min_attempts. Verifies the floor does NOT force retries
-    on permanent failures."""
 
     def test_t11_permanent_error_one_attempt_sync(self, fake_clock):
         retries_config = _retries(min_attempts=10)
@@ -643,7 +541,6 @@ class TestPermanentErrorShortCircuit:
 
         with pytest.raises(ValueError, match="permanent"):
             retry(func, retries_config)
-        # Even with min_attempts=10, PermanentError short-circuits.
         assert call_count == 1
 
     def test_t11_permanent_error_one_attempt_async(self, fake_clock):

--- a/_test_unstructured_client/unit/test_retries.py
+++ b/_test_unstructured_client/unit/test_retries.py
@@ -1,19 +1,113 @@
-"""Tests for retry logic covering all TransportError subclasses."""
+"""Tests for retry logic covering all TransportError subclasses
+and the FS-1988 min_attempts / absolute_max_elapsed_time_ms semantics."""
 
 import asyncio
+import time as time_module
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 
+from unstructured_client.utils import retries as retries_module
 from unstructured_client.utils.retries import (
     BackoffStrategy,
     PermanentError,
     Retries,
     RetryConfig,
+    TemporaryError,
     retry,
     retry_async,
 )
+
+
+# -----------------------------------------------------------------
+# FS-1988 fake-clock harness
+#
+# `retries.py` reads `time.time()` and calls `time.sleep()` /
+# `asyncio.sleep()`. The retries module imports `time` and `asyncio`
+# at module scope, so we patch those module attributes. Each test
+# starts the clock at 0ms and advances it explicitly:
+#   - `time.sleep(s)` advances the fake clock by s*1000 ms
+#   - `asyncio.sleep(s)` advances the fake clock by s*1000 ms
+#   - the test `func` callable advances the clock by its own simulated
+#     attempt duration before raising / returning
+# -----------------------------------------------------------------
+
+
+class FakeClock:
+    """Mutable monotonic clock for retry loop tests.
+
+    Tracks elapsed milliseconds since fixture creation. `now_ms` is
+    incremented by patched sleep functions and by test func() bodies.
+    `time()` returns a float seconds value compatible with
+    `round(time.time() * 1000)` patterns in retries.py.
+    """
+
+    def __init__(self):
+        self.now_ms = 0
+
+    def time(self) -> float:
+        return self.now_ms / 1000.0
+
+    def advance(self, milliseconds: int) -> None:
+        self.now_ms += int(milliseconds)
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    clock = FakeClock()
+
+    def fake_time():
+        return clock.time()
+
+    def fake_sync_sleep(seconds):
+        clock.advance(int(seconds * 1000))
+
+    async def fake_async_sleep(seconds):
+        clock.advance(int(seconds * 1000))
+
+    monkeypatch.setattr(retries_module.time, "time", fake_time)
+    monkeypatch.setattr(retries_module.time, "sleep", fake_sync_sleep)
+    monkeypatch.setattr(retries_module.asyncio, "sleep", fake_async_sleep)
+    # Strip jitter so backoff durations are exactly reproducible.
+    monkeypatch.setattr(
+        retries_module.random, "uniform", lambda a, b: 0.0
+    )
+    return clock
+
+
+def _retries(
+    *,
+    initial_interval: int = 100,
+    max_interval: int = 200,
+    exponent: float = 1.5,
+    max_elapsed_time: int = 5_000,
+    min_attempts: int = 0,
+    absolute_max_elapsed_time_ms=None,
+    retry_connection_errors: bool = True,
+    status_codes=None,
+) -> Retries:
+    return Retries(
+        config=RetryConfig(
+            strategy="backoff",
+            backoff=BackoffStrategy(
+                initial_interval=initial_interval,
+                max_interval=max_interval,
+                exponent=exponent,
+                max_elapsed_time=max_elapsed_time,
+                min_attempts=min_attempts,
+                absolute_max_elapsed_time_ms=absolute_max_elapsed_time_ms,
+            ),
+            retry_connection_errors=retry_connection_errors,
+        ),
+        status_codes=status_codes or [],
+    )
+
+
+def _make_ok_response(status_code: int = 200) -> httpx.Response:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    return resp
 
 
 def _make_retries(retry_connection_errors: bool) -> Retries:
@@ -109,3 +203,458 @@ class TestTransportErrorRetryAsync:
 
         with pytest.raises(exc_class):
             asyncio.run(retry_async(func, retries_config))
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: BackoffStrategy validation (T12-T14)
+# These do not need the fake-clock harness.
+# -----------------------------------------------------------------
+
+
+class TestBackoffStrategyValidation:
+    def test_t12_negative_min_attempts_rejected(self):
+        with pytest.raises(ValueError, match="min_attempts must be >= 0"):
+            BackoffStrategy(
+                initial_interval=100,
+                max_interval=200,
+                exponent=1.5,
+                max_elapsed_time=5_000,
+                min_attempts=-1,
+            )
+
+    def test_t13_zero_absolute_max_rejected(self):
+        with pytest.raises(ValueError, match="absolute_max_elapsed_time_ms must be > 0"):
+            BackoffStrategy(
+                initial_interval=100,
+                max_interval=200,
+                exponent=1.5,
+                max_elapsed_time=5_000,
+                absolute_max_elapsed_time_ms=0,
+            )
+
+    def test_t14_absolute_max_below_soft_max_rejected(self):
+        with pytest.raises(
+            ValueError,
+            match="absolute_max_elapsed_time_ms must be >= max_elapsed_time",
+        ):
+            BackoffStrategy(
+                initial_interval=100,
+                max_interval=200,
+                exponent=1.5,
+                max_elapsed_time=10_000,
+                absolute_max_elapsed_time_ms=5_000,
+            )
+
+    def test_min_attempts_zero_accepted(self):
+        BackoffStrategy(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=5_000,
+            min_attempts=0,
+        )
+
+    def test_absolute_max_equal_to_soft_max_accepted(self):
+        BackoffStrategy(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=5_000,
+            absolute_max_elapsed_time_ms=5_000,
+        )
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: T1, T2 -- backward compatibility (min_attempts=0)
+# -----------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_t1_no_failures_sync(self, fake_clock):
+        retries_config = _retries()
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            return _make_ok_response()
+
+        result = retry(func, retries_config)
+        assert result.status_code == 200
+        assert call_count == 1
+
+    def test_t1_no_failures_async(self, fake_clock):
+        retries_config = _retries()
+        call_count = 0
+
+        async def func():
+            nonlocal call_count
+            call_count += 1
+            return _make_ok_response()
+
+        result = asyncio.run(retry_async(func, retries_config))
+        assert result.status_code == 200
+        assert call_count == 1
+
+    def test_t2_one_transient_then_success_sync(self, fake_clock):
+        retries_config = _retries()
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ConnectError("transient")
+            return _make_ok_response()
+
+        result = retry(func, retries_config)
+        assert result.status_code == 200
+        assert call_count == 2
+
+    def test_t2_one_transient_then_success_async(self, fake_clock):
+        retries_config = _retries()
+        call_count = 0
+
+        async def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.ConnectError("transient")
+            return _make_ok_response()
+
+        result = asyncio.run(retry_async(func, retries_config))
+        assert result.status_code == 200
+        assert call_count == 2
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: T3 -- the v1 reproducer.
+# Attempt 1 takes longer than the soft cap; the min_attempts floor
+# must permit attempt 2 to fire, which then succeeds.
+# -----------------------------------------------------------------
+
+
+class TestSoftCapFloor:
+    def test_t3_slow_first_attempt_then_success_sync(self, fake_clock):
+        # Soft cap 5s, attempt 1 takes 6s, min_attempts=2.
+        retries_config = _retries(
+            max_elapsed_time=5_000,
+            min_attempts=2,
+        )
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fake_clock.advance(6_000)  # 6s
+                raise httpx.ReadTimeout("slow")
+            return _make_ok_response()
+
+        result = retry(func, retries_config)
+        assert result.status_code == 200
+        assert call_count == 2
+
+    def test_t3_slow_first_attempt_then_success_async(self, fake_clock):
+        retries_config = _retries(
+            max_elapsed_time=5_000,
+            min_attempts=2,
+        )
+        call_count = 0
+
+        async def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fake_clock.advance(6_000)
+                raise httpx.ReadTimeout("slow")
+            return _make_ok_response()
+
+        result = asyncio.run(retry_async(func, retries_config))
+        assert result.status_code == 200
+        assert call_count == 2
+
+    def test_t3_baseline_pre_fix_behavior(self, fake_clock):
+        """Without the min_attempts floor (min_attempts=0), the same
+        scenario short-circuits with no retries -- this is the pre-fix
+        regression. Documents the bug class we are closing."""
+        retries_config = _retries(
+            max_elapsed_time=5_000,
+            min_attempts=0,
+        )
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fake_clock.advance(6_000)
+                raise httpx.ReadTimeout("slow")
+            return _make_ok_response()
+
+        # Without the floor, soft cap fires on attempt 1's failure and
+        # the loop raises the wrapped ReadTimeout.
+        with pytest.raises(httpx.ReadTimeout):
+            retry(func, retries_config)
+        assert call_count == 1
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: T4, T5 -- floor is NOT a ceiling.
+# -----------------------------------------------------------------
+
+
+class TestFloorIsNotCeiling:
+    def test_t4_floor_does_not_cap_attempts_sync(self, fake_clock):
+        """min_attempts=2 with 5 transient failures + budget should
+        produce 6 total attempts, NOT 3."""
+        retries_config = _retries(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=60_000,  # generous budget
+            min_attempts=2,
+        )
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise httpx.ConnectError("transient")
+            return _make_ok_response()
+
+        result = retry(func, retries_config)
+        assert result.status_code == 200
+        assert call_count == 6
+
+    def test_t5_floor_then_soft_cap_sync(self, fake_clock):
+        """With min_attempts=2 and all attempts failing fast, the
+        loop must fire AT LEAST 3 total attempts (initial + 2 retries)
+        before the soft cap can cut in."""
+        retries_config = _retries(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=10_000,
+            min_attempts=2,
+        )
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            # Each attempt itself is instantaneous; only the backoff
+            # sleep advances the fake clock.
+            raise httpx.ConnectError("transient")
+
+        with pytest.raises(httpx.ConnectError):
+            retry(func, retries_config)
+        # 3 = initial + 2 retries (the min_attempts floor)
+        assert call_count >= 3
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: T6, T7 -- hard cap overrides the floor; sleep
+# truncation prevents sleeping into a doomed retry.
+# -----------------------------------------------------------------
+
+
+class TestHardCap:
+    def test_t6_hard_cap_overrides_floor_sync(self, fake_clock):
+        """min_attempts=2 but attempt 1 takes longer than the hard
+        cap. Hard cap must fire even though the floor is unsatisfied."""
+        retries_config = _retries(
+            max_elapsed_time=5_000,
+            min_attempts=2,
+            absolute_max_elapsed_time_ms=10_000,
+        )
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fake_clock.advance(11_000)  # 11s > 10s hard cap
+                raise httpx.ReadTimeout("slow")
+            return _make_ok_response()
+
+        with pytest.raises(httpx.ReadTimeout):
+            retry(func, retries_config)
+        # Hard cap fires after attempt 1; no further attempts.
+        assert call_count == 1
+
+    def test_t6_hard_cap_overrides_floor_async(self, fake_clock):
+        retries_config = _retries(
+            max_elapsed_time=5_000,
+            min_attempts=2,
+            absolute_max_elapsed_time_ms=10_000,
+        )
+        call_count = 0
+
+        async def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fake_clock.advance(11_000)
+                raise httpx.ReadTimeout("slow")
+            return _make_ok_response()
+
+        with pytest.raises(httpx.ReadTimeout):
+            asyncio.run(retry_async(func, retries_config))
+        assert call_count == 1
+
+    def test_t7_sleep_truncation_prevents_doomed_retry_sync(self, fake_clock):
+        """Hard cap pre-emptive check: if the sleep alone would push
+        past the cap, raise immediately rather than sleeping into a
+        retry that can never start."""
+        # Soft cap 5s, hard cap 10s, attempt 1 takes 9.95s.
+        # Sleep starts at 100ms * 1.5^0 = 100ms (no jitter in tests),
+        # but we want to assert the sleep+elapsed > hard_cap path
+        # fires. Use larger initial_interval to make the calculation
+        # land deterministically.
+        retries_config = _retries(
+            initial_interval=200,  # 200ms initial
+            max_interval=1_000,
+            exponent=2.0,
+            max_elapsed_time=5_000,
+            min_attempts=2,  # floor is unsatisfied; only hard cap can cut
+            absolute_max_elapsed_time_ms=10_000,
+        )
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # attempt 1 lasts 9.95s -> elapsed = 9.95s, sleep would be
+                # 200ms -> projected = 10.15s >= hard cap 10s -> raise.
+                fake_clock.advance(9_950)
+                raise httpx.ReadTimeout("slow")
+            return _make_ok_response()
+
+        with pytest.raises(httpx.ReadTimeout):
+            retry(func, retries_config)
+        assert call_count == 1
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: T8, T9, T10 -- TemporaryError (retryable 5xx)
+# early-return behavior under soft and hard cap exhaustion.
+# -----------------------------------------------------------------
+
+
+class TestTemporaryErrorEarlyReturn:
+    def test_t8_soft_cap_5xx_returns_last_response_sync(self, fake_clock):
+        """min_attempts=0, retryable 5xx, soft cap exhausted: returns
+        the last 5xx response (existing behavior)."""
+        retries_config = _retries(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=500,
+            min_attempts=0,
+            status_codes=["5xx"],
+        )
+        bad_response = _make_ok_response(status_code=503)
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            # Each attempt itself is instant; backoff sleep accumulates.
+            return bad_response
+
+        result = retry(func, retries_config)
+        # Should return the last 5xx response, not raise.
+        assert result.status_code == 503
+        assert call_count >= 1
+
+    def test_t9_floor_then_soft_cap_5xx_returns_last_response_sync(self, fake_clock):
+        retries_config = _retries(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=1_000,
+            min_attempts=2,
+            status_codes=["5xx"],
+        )
+        bad_response = _make_ok_response(status_code=503)
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            return bad_response
+
+        result = retry(func, retries_config)
+        assert result.status_code == 503
+        # Floor enforced: at least initial + 2 retries before soft cap.
+        assert call_count >= 3
+
+    def test_t10_hard_cap_5xx_returns_last_response_sync(self, fake_clock):
+        """Hard cap fires; TemporaryError still returns the response,
+        not a raised exception."""
+        retries_config = _retries(
+            initial_interval=100,
+            max_interval=200,
+            exponent=1.5,
+            max_elapsed_time=5_000,
+            min_attempts=2,
+            absolute_max_elapsed_time_ms=10_000,
+            status_codes=["5xx"],
+        )
+        bad_response = _make_ok_response(status_code=503)
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fake_clock.advance(11_000)  # past hard cap
+            return bad_response
+
+        result = retry(func, retries_config)
+        assert result.status_code == 503
+        assert call_count == 1
+
+
+# -----------------------------------------------------------------
+# FS-1988 tests: T11 -- PermanentError unaffected by min_attempts.
+# -----------------------------------------------------------------
+
+
+class TestPermanentErrorShortCircuit:
+    """A non-transport, non-status-code exception raised from func() is
+    wrapped by retry/retry_async's inner do_request closure in a
+    PermanentError. The outer retry_with_backoff{,_async} catches
+    PermanentError and re-raises `.inner`, which short-circuits the loop
+    regardless of min_attempts. Verifies the floor does NOT force retries
+    on permanent failures."""
+
+    def test_t11_permanent_error_one_attempt_sync(self, fake_clock):
+        retries_config = _retries(min_attempts=10)
+        call_count = 0
+
+        def func():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("permanent")
+
+        with pytest.raises(ValueError, match="permanent"):
+            retry(func, retries_config)
+        # Even with min_attempts=10, PermanentError short-circuits.
+        assert call_count == 1
+
+    def test_t11_permanent_error_one_attempt_async(self, fake_clock):
+        retries_config = _retries(min_attempts=10)
+        call_count = 0
+
+        async def func():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("permanent")
+
+        with pytest.raises(ValueError, match="permanent"):
+            asyncio.run(retry_async(func, retries_config))
+        assert call_count == 1

--- a/src/unstructured_client/utils/retries.py
+++ b/src/unstructured_client/utils/retries.py
@@ -25,33 +25,9 @@ class BackoffStrategy:
         min_attempts: int = 0,
         absolute_max_elapsed_time_ms: int | None = None,
     ):
-        # `min_attempts`: minimum number of RETRY attempts (NOT counting
-        # the initial attempt) that must fire before `max_elapsed_time`
-        # is honored. Despite the name, this counts retries only:
-        # `min_attempts=2` permits the initial attempt PLUS at least 2
-        # retries (3 total attempts) before the soft elapsed-time budget
-        # can cut the loop. Default `0` preserves prior behavior (budget
-        # honored from the first failed attempt). The field is named
-        # `min_attempts` for symmetry with the existing public-API
-        # vocabulary; the docstring is the contract.
-        # Exists to close the short-circuit where a single slow first
-        # attempt blows the soft budget and silently disables retries on
-        # subsequent transient errors. See FS-1988.
-        #
-        # `absolute_max_elapsed_time_ms`: cap on when a new retry can
-        # START. When set, no new retry attempt will be started past
-        # this elapsed time, regardless of `min_attempts`. In-flight
-        # `func()` calls are NOT interrupted — an attempt that begins
-        # just before the cap may run to its per-attempt timeout (e.g.
-        # the httpx client timeout) and exceed the cap. Worst-case
-        # wall-clock under this cap is therefore
-        # `absolute_max_elapsed_time_ms + per_attempt_timeout`, not
-        # `absolute_max_elapsed_time_ms`. To bound the true wall-clock,
-        # pair this with a per-attempt timeout no larger than the
-        # acceptable additional headroom past the cap.
-        # Default `None` preserves prior behavior (no cap on retry
-        # start; `min_attempts` and `max_elapsed_time` alone gate the
-        # loop). See FS-1988 PLAN.md "Worst-case wall-clock" section.
+        # min_attempts counts retries (not the initial attempt).
+        # absolute_max_elapsed_time_ms caps when a new retry can start;
+        # it does not interrupt in-flight func() calls.
         if min_attempts < 0:
             raise ValueError(
                 f"min_attempts must be >= 0, got {min_attempts}"
@@ -210,12 +186,6 @@ def _cap_hit_after_attempt(
     max_elapsed_time,
     absolute_max_elapsed_time_ms,
 ):
-    """Return True if either the soft or hard cap is already exceeded.
-
-    Called after an attempt fails, before deciding to sleep. Soft cap is
-    only honored once the `min_attempts` retry floor is satisfied; hard
-    cap (if set) is honored unconditionally.
-    """
     soft_cap_hit = retries >= min_attempts and elapsed_ms > max_elapsed_time
     hard_cap_hit = (
         absolute_max_elapsed_time_ms is not None
@@ -225,9 +195,6 @@ def _cap_hit_after_attempt(
 
 
 def _raise_or_return_after_cap(exception, elapsed_ms, retries, reason):
-    """Final handling when a cap is hit. Mirrors the original behavior
-    of returning the TemporaryError's response for retryable status codes
-    so the caller sees the last response rather than a stack trace."""
     if isinstance(exception, TemporaryError):
         return exception.response
     elapsed_seconds = elapsed_ms / 1000
@@ -258,8 +225,6 @@ def retry_with_backoff(
             now = round(time.time() * 1000)
             elapsed = now - start
 
-            # Post-attempt cap check: either cap exceeded by the attempt
-            # that just finished -> stop the loop.
             if _cap_hit_after_attempt(
                 elapsed,
                 retries,
@@ -278,11 +243,6 @@ def retry_with_backoff(
             )
             sleep_seconds = min(sleep_seconds, max_interval / 1000)
 
-            # Pre-emptive hard-cap check: if the sleep alone would push us
-            # past the hard cap, no point sleeping into a doomed retry.
-            # Note: this prevents STARTING a new attempt past the cap, it
-            # does NOT interrupt an in-flight func() -- see docstring on
-            # BackoffStrategy.absolute_max_elapsed_time_ms.
             if absolute_max_elapsed_time_ms is not None:
                 projected_elapsed = elapsed + int(sleep_seconds * 1000)
                 if projected_elapsed >= absolute_max_elapsed_time_ms:
@@ -296,10 +256,6 @@ def retry_with_backoff(
 
             time.sleep(sleep_seconds)
 
-            # Post-sleep verification: belt-and-suspenders against late
-            # wakeups (OS scheduling) and rounding errors in the
-            # pre-sleep projection. If the actual elapsed time after the
-            # sleep is past the hard cap, do not start the next attempt.
             if absolute_max_elapsed_time_ms is not None:
                 actual_elapsed = round(time.time() * 1000) - start
                 if actual_elapsed >= absolute_max_elapsed_time_ms:
@@ -366,11 +322,6 @@ async def retry_with_backoff_async(
 
             await asyncio.sleep(sleep_seconds)
 
-            # Post-sleep verification: belt-and-suspenders against late
-            # wakeups (event loop scheduling, asyncio.sleep imprecision)
-            # and rounding errors in the pre-sleep projection. If the
-            # actual elapsed time after the sleep is past the hard cap,
-            # do not start the next attempt.
             if absolute_max_elapsed_time_ms is not None:
                 actual_elapsed = round(time.time() * 1000) - start
                 if actual_elapsed >= absolute_max_elapsed_time_ms:

--- a/src/unstructured_client/utils/retries.py
+++ b/src/unstructured_client/utils/retries.py
@@ -13,6 +13,8 @@ class BackoffStrategy:
     max_interval: int
     exponent: float
     max_elapsed_time: int
+    min_attempts: int
+    absolute_max_elapsed_time_ms: int | None
 
     def __init__(
         self,
@@ -20,11 +22,57 @@ class BackoffStrategy:
         max_interval: int,
         exponent: float,
         max_elapsed_time: int,
+        min_attempts: int = 0,
+        absolute_max_elapsed_time_ms: int | None = None,
     ):
+        # `min_attempts`: minimum number of RETRY attempts (NOT counting
+        # the initial attempt) that must fire before `max_elapsed_time`
+        # is honored. Despite the name, this counts retries only:
+        # `min_attempts=2` permits the initial attempt PLUS at least 2
+        # retries (3 total attempts) before the soft elapsed-time budget
+        # can cut the loop. Default `0` preserves prior behavior (budget
+        # honored from the first failed attempt). The field is named
+        # `min_attempts` for symmetry with the existing public-API
+        # vocabulary; the docstring is the contract.
+        # Exists to close the short-circuit where a single slow first
+        # attempt blows the soft budget and silently disables retries on
+        # subsequent transient errors. See FS-1988.
+        #
+        # `absolute_max_elapsed_time_ms`: cap on when a new retry can
+        # START. When set, no new retry attempt will be started past
+        # this elapsed time, regardless of `min_attempts`. In-flight
+        # `func()` calls are NOT interrupted — an attempt that begins
+        # just before the cap may run to its per-attempt timeout (e.g.
+        # the httpx client timeout) and exceed the cap. Worst-case
+        # wall-clock under this cap is therefore
+        # `absolute_max_elapsed_time_ms + per_attempt_timeout`, not
+        # `absolute_max_elapsed_time_ms`. To bound the true wall-clock,
+        # pair this with a per-attempt timeout no larger than the
+        # acceptable additional headroom past the cap.
+        # Default `None` preserves prior behavior (no cap on retry
+        # start; `min_attempts` and `max_elapsed_time` alone gate the
+        # loop). See FS-1988 PLAN.md "Worst-case wall-clock" section.
+        if min_attempts < 0:
+            raise ValueError(
+                f"min_attempts must be >= 0, got {min_attempts}"
+            )
+        if absolute_max_elapsed_time_ms is not None:
+            if absolute_max_elapsed_time_ms <= 0:
+                raise ValueError(
+                    "absolute_max_elapsed_time_ms must be > 0, "
+                    f"got {absolute_max_elapsed_time_ms}"
+                )
+            if absolute_max_elapsed_time_ms < max_elapsed_time:
+                raise ValueError(
+                    "absolute_max_elapsed_time_ms must be >= max_elapsed_time "
+                    f"({max_elapsed_time}), got {absolute_max_elapsed_time_ms}"
+                )
         self.initial_interval = initial_interval
         self.max_interval = max_interval
         self.exponent = exponent
         self.max_elapsed_time = max_elapsed_time
+        self.min_attempts = min_attempts
+        self.absolute_max_elapsed_time_ms = absolute_max_elapsed_time_ms
 
 
 class RetryConfig:
@@ -102,6 +150,8 @@ def retry(func, retries: Retries):
             retries.config.backoff.max_interval,
             retries.config.backoff.exponent,
             retries.config.backoff.max_elapsed_time,
+            retries.config.backoff.min_attempts,
+            retries.config.backoff.absolute_max_elapsed_time_ms,
         )
 
     return func()
@@ -146,9 +196,45 @@ async def retry_async(func, retries: Retries):
             retries.config.backoff.max_interval,
             retries.config.backoff.exponent,
             retries.config.backoff.max_elapsed_time,
+            retries.config.backoff.min_attempts,
+            retries.config.backoff.absolute_max_elapsed_time_ms,
         )
 
     return await func()
+
+
+def _cap_hit_after_attempt(
+    elapsed_ms,
+    retries,
+    min_attempts,
+    max_elapsed_time,
+    absolute_max_elapsed_time_ms,
+):
+    """Return True if either the soft or hard cap is already exceeded.
+
+    Called after an attempt fails, before deciding to sleep. Soft cap is
+    only honored once the `min_attempts` retry floor is satisfied; hard
+    cap (if set) is honored unconditionally.
+    """
+    soft_cap_hit = retries >= min_attempts and elapsed_ms > max_elapsed_time
+    hard_cap_hit = (
+        absolute_max_elapsed_time_ms is not None
+        and elapsed_ms > absolute_max_elapsed_time_ms
+    )
+    return soft_cap_hit or hard_cap_hit
+
+
+def _raise_or_return_after_cap(exception, elapsed_ms, retries, reason):
+    """Final handling when a cap is hit. Mirrors the original behavior
+    of returning the TemporaryError's response for retryable status codes
+    so the caller sees the last response rather than a stack trace."""
+    if isinstance(exception, TemporaryError):
+        return exception.response
+    elapsed_seconds = elapsed_ms / 1000
+    raise type(exception)(
+        f"{type(exception).__name__} after {retries + 1} attempts "
+        f"over {elapsed_seconds:.1f}s{reason}: {exception}"
+    ) from exception
 
 
 def retry_with_backoff(
@@ -157,6 +243,8 @@ def retry_with_backoff(
     max_interval=60000,
     exponent=1.5,
     max_elapsed_time=3600000,
+    min_attempts=0,
+    absolute_max_elapsed_time_ms=None,
 ):
     start = round(time.time() * 1000)
     retries = 0
@@ -168,18 +256,61 @@ def retry_with_backoff(
             raise exception.inner
         except Exception as exception:  # pylint: disable=broad-exception-caught
             now = round(time.time() * 1000)
-            if now - start > max_elapsed_time:
-                if isinstance(exception, TemporaryError):
-                    return exception.response
+            elapsed = now - start
 
-                elapsed_seconds = (now - start) / 1000
-                raise type(exception)(
-                    f"{type(exception).__name__} after {retries + 1} attempts "
-                    f"over {elapsed_seconds:.1f}s: {exception}"
-                ) from exception
-            sleep = (initial_interval / 1000) * exponent**retries + random.uniform(0, 1)
-            sleep = min(sleep, max_interval / 1000)
-            time.sleep(sleep)
+            # Post-attempt cap check: either cap exceeded by the attempt
+            # that just finished -> stop the loop.
+            if _cap_hit_after_attempt(
+                elapsed,
+                retries,
+                min_attempts,
+                max_elapsed_time,
+                absolute_max_elapsed_time_ms,
+            ):
+                result = _raise_or_return_after_cap(
+                    exception, elapsed, retries, ""
+                )
+                return result
+
+            sleep_seconds = (
+                (initial_interval / 1000) * exponent**retries
+                + random.uniform(0, 1)
+            )
+            sleep_seconds = min(sleep_seconds, max_interval / 1000)
+
+            # Pre-emptive hard-cap check: if the sleep alone would push us
+            # past the hard cap, no point sleeping into a doomed retry.
+            # Note: this prevents STARTING a new attempt past the cap, it
+            # does NOT interrupt an in-flight func() -- see docstring on
+            # BackoffStrategy.absolute_max_elapsed_time_ms.
+            if absolute_max_elapsed_time_ms is not None:
+                projected_elapsed = elapsed + int(sleep_seconds * 1000)
+                if projected_elapsed >= absolute_max_elapsed_time_ms:
+                    result = _raise_or_return_after_cap(
+                        exception,
+                        elapsed,
+                        retries,
+                        " (hard cap would be exceeded during backoff)",
+                    )
+                    return result
+
+            time.sleep(sleep_seconds)
+
+            # Post-sleep verification: belt-and-suspenders against late
+            # wakeups (OS scheduling) and rounding errors in the
+            # pre-sleep projection. If the actual elapsed time after the
+            # sleep is past the hard cap, do not start the next attempt.
+            if absolute_max_elapsed_time_ms is not None:
+                actual_elapsed = round(time.time() * 1000) - start
+                if actual_elapsed >= absolute_max_elapsed_time_ms:
+                    result = _raise_or_return_after_cap(
+                        exception,
+                        actual_elapsed,
+                        retries,
+                        " (hard cap reached during backoff sleep)",
+                    )
+                    return result
+
             retries += 1
 
 
@@ -189,6 +320,8 @@ async def retry_with_backoff_async(
     max_interval=60000,
     exponent=1.5,
     max_elapsed_time=3600000,
+    min_attempts=0,
+    absolute_max_elapsed_time_ms=None,
 ):
     start = round(time.time() * 1000)
     retries = 0
@@ -200,16 +333,53 @@ async def retry_with_backoff_async(
             raise exception.inner
         except Exception as exception:  # pylint: disable=broad-exception-caught
             now = round(time.time() * 1000)
-            if now - start > max_elapsed_time:
-                if isinstance(exception, TemporaryError):
-                    return exception.response
+            elapsed = now - start
 
-                elapsed_seconds = (now - start) / 1000
-                raise type(exception)(
-                    f"{type(exception).__name__} after {retries + 1} attempts "
-                    f"over {elapsed_seconds:.1f}s: {exception}"
-                ) from exception
-            sleep = (initial_interval / 1000) * exponent**retries + random.uniform(0, 1)
-            sleep = min(sleep, max_interval / 1000)
-            await asyncio.sleep(sleep)
+            if _cap_hit_after_attempt(
+                elapsed,
+                retries,
+                min_attempts,
+                max_elapsed_time,
+                absolute_max_elapsed_time_ms,
+            ):
+                result = _raise_or_return_after_cap(
+                    exception, elapsed, retries, ""
+                )
+                return result
+
+            sleep_seconds = (
+                (initial_interval / 1000) * exponent**retries
+                + random.uniform(0, 1)
+            )
+            sleep_seconds = min(sleep_seconds, max_interval / 1000)
+
+            if absolute_max_elapsed_time_ms is not None:
+                projected_elapsed = elapsed + int(sleep_seconds * 1000)
+                if projected_elapsed >= absolute_max_elapsed_time_ms:
+                    result = _raise_or_return_after_cap(
+                        exception,
+                        elapsed,
+                        retries,
+                        " (hard cap would be exceeded during backoff)",
+                    )
+                    return result
+
+            await asyncio.sleep(sleep_seconds)
+
+            # Post-sleep verification: belt-and-suspenders against late
+            # wakeups (event loop scheduling, asyncio.sleep imprecision)
+            # and rounding errors in the pre-sleep projection. If the
+            # actual elapsed time after the sleep is past the hard cap,
+            # do not start the next attempt.
+            if absolute_max_elapsed_time_ms is not None:
+                actual_elapsed = round(time.time() * 1000) - start
+                if actual_elapsed >= absolute_max_elapsed_time_ms:
+                    result = _raise_or_return_after_cap(
+                        exception,
+                        actual_elapsed,
+                        retries,
+                        " (hard cap reached during backoff sleep)",
+                    )
+                    return result
+
             retries += 1


### PR DESCRIPTION
## Summary

`retry_with_backoff_async` currently checks `now - start > max_elapsed_time` *before* sleeping. When `RetryConfig.max_elapsed_time` is set to e.g. 5 min and the per-attempt httpx client timeout is 30 min, any attempt that runs longer than the budget blows it on attempt 1 — **zero retries fire on subsequent transient errors**. Closes that short-circuit without re-introducing the unbounded retry loops that recent budget tightening was meant to prevent.

## What changes

New optional fields on `BackoffStrategy` (default values preserve existing behavior):

- `min_attempts: int = 0` — minimum retry attempts that must fire before `max_elapsed_time` is honored. Counts retries, not the initial attempt. `min_attempts=2` permits 1 initial + at least 2 retries (3 total attempts) before the soft cap can cut the loop.
- `absolute_max_elapsed_time_ms: int | None = None` — cap on when a new retry can START. Does NOT interrupt an in-flight `func()` call. Worst-case wall-clock under this cap is `absolute_max_elapsed_time_ms + per_attempt_timeout`.

Loop changes in both sync (`retry_with_backoff`) and async (`retry_with_backoff_async`) paths:

1. **Post-attempt cap check.** Soft cap honored only when `retries >= min_attempts`; hard cap unconditional.
2. **Pre-sleep hard-cap check.** Refuses to sleep into a retry whose projected start would cross the hard cap.
3. **Post-sleep verification.** Belt-and-suspenders against late wakeups and projection rounding.
4. **Helper extraction** (`_cap_hit_after_attempt`, `_raise_or_return_after_cap`) dedupes the soft/hard cap logic between sync and async.

Validation in `BackoffStrategy.__init__` rejects `min_attempts < 0`, `absolute_max_elapsed_time_ms <= 0`, and hard cap below soft cap.

`.genignore` updated to preserve these fields across future Speakeasy regens, matching the `general.py` and `users.py` precedent.

## Design choices

- **Hard cap is a retry-start cap, not a wall-clock bound.** In-flight `func()` cannot be interrupted from the retry loop. Consumers should pair the cap with a sensible per-attempt timeout to keep the worst case bounded.
- **Defaults preserve existing behavior** so this change is non-breaking for every existing consumer. Consumers opt in by setting `min_attempts > 0` and/or `absolute_max_elapsed_time_ms`.

## Tests

49 tests pass (46 unit + 3 split-PDF retry integration). New coverage:

- **T1–T14** in `_test_unstructured_client/unit/test_retries.py`: fake-clock harness monkeypatching `time.time` / `time.sleep` / `asyncio.sleep` / `random.uniform`. Covers the slow-first-attempt + `min_attempts` floor scenario, floor-is-not-a-ceiling semantics, hard cap overrides floor, sleep truncation, `TemporaryError` early-return through both caps, `PermanentError` short-circuit immunity, and `BackoffStrategy.__init__` validation.
- **`test_split_pdf_cache_tmp_data_chunk_request_stream_is_replay_safe`** in `integration/test_decorators.py`: pins the body-replay invariant for chunk requests built from open file objects (the `split_pdf_cache_tmp_data=True` path). Iterates `request.stream` twice directly — bypasses `request.read()` caching — so a future Speakeasy template change that produced a single-consumption stream would fail this test.

## Test plan

- [x] `uv run pytest _test_unstructured_client/unit/test_retries.py` — 46 pass
- [x] `uv run pytest _test_unstructured_client/integration/test_decorators.py::test_split_pdf_*retry* _test_unstructured_client/integration/test_decorators.py::test_split_pdf_cache_tmp_data_*` — 3 pass
- [ ] CI green