### PR TITLE
chore: bump to 0.44.1 to release retry budget fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## 0.44.1
+
+### Features
+* Add `min_attempts` and `absolute_max_elapsed_time_ms` fields to `BackoffStrategy`. `min_attempts` is the minimum number of retry attempts that must fire before `max_elapsed_time` is honored; defaults to `0` (preserves existing behavior). `absolute_max_elapsed_time_ms` caps when a new retry can start (does not interrupt in-flight requests); defaults to `None`. Together these close a short-circuit where a single slow first attempt could exhaust the retry budget before any retry fired.
+
 ## 0.44.0
 
 ### Breaking changes
 * Removed deprecated connector config models from the SDK (e.g. `S3SourceConnectorConfig`, `AzureDestinationConnectorConfig`). Pass connector configs as plain dicts with arbitrary fields. The SDK is no longer coupled to backend connector schemas — new fields work without an SDK upgrade.
-
-### Features
-* Add `min_attempts` and `absolute_max_elapsed_time_ms` fields to `BackoffStrategy`. `min_attempts` is the minimum number of retry attempts that must fire before `max_elapsed_time` is honored; defaults to `0` (preserves existing behavior). `absolute_max_elapsed_time_ms` caps when a new retry can start (does not interrupt in-flight requests); defaults to `None`. Together these close a short-circuit where a single slow first attempt could exhaust the retry budget before any retry fired. See FS-1988.
 
 ## 0.43.4
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1221,3 +1221,13 @@ Based on:
 - [python v0.44.0] .
 ### Releases
 - [PyPI v0.44.0 ] https://pypi.org/project/unstructured-client/0.44.0 - .
+
+## 2026-05-27 16:00:00
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.601.0 (2.680.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v0.44.1] .
+### Releases
+- [PyPI v0.44.1] https://pypi.org/project/unstructured-client/0.44.1 - .

--- a/src/unstructured_client/_version.py
+++ b/src/unstructured_client/_version.py
@@ -3,10 +3,10 @@
 import importlib.metadata
 
 __title__: str = "unstructured-client"
-__version__: str = "0.44.0"
+__version__: str = "0.44.1"
 __openapi_doc_version__: str = "1.2.31"
 __gen_version__: str = "2.680.0"
-__user_agent__: str = "speakeasy-sdk/python 0.44.0 2.680.0 1.2.31 unstructured-client"
+__user_agent__: str = "speakeasy-sdk/python 0.44.1 2.680.0 1.2.31 unstructured-client"
 
 try:
     if __package__ is not None:


### PR DESCRIPTION
## Summary

Cuts a 0.44.1 release so the `BackoffStrategy` retry-budget fields that landed on main in #342 actually ship to PyPI. v0.44.0 was tagged before #342 merged, so PyPI v0.44.0 does not include those fields.

## Changes

- `src/unstructured_client/_version.py`: bump `__version__` and `__user_agent__` to `0.44.1`.
- `CHANGELOG.md`: split the combined 0.44.0 entry — `min_attempts` / `absolute_max_elapsed_time_ms` move under a new `## 0.44.1` section so the changelog matches what's actually in each PyPI artifact.
- `RELEASES.md`: append a 0.44.1 entry following the existing Speakeasy-publish format.

## Test plan

- [x] No code changes; only metadata files
- [ ] CI green
- [ ] PyPI publish workflow picks up the bump on merge